### PR TITLE
fix: support App Store and latest KakaoTalk Mac versions

### DIFF
--- a/Sources/KakaoCLI/Commands/AuthCommand.swift
+++ b/Sources/KakaoCLI/Commands/AuthCommand.swift
@@ -28,56 +28,117 @@ struct AuthCommand: ParsableCommand {
         print("UUID: \(deviceUUID)")
 
         // 2. Get user ID
-        let uid: Int
+        let uid: Int?
         if let override = userId {
             uid = override
+            print("User ID: \(override) (override)")
         } else {
             do {
-                uid = try DeviceInfo.userId()
-            } catch let error as KakaoError {
-                print("Error: \(error)")
-                print("\nCould not auto-detect user ID.")
-                print("Try: kakaocli auth --user-id <YOUR_KAKAO_USER_ID>")
-                print("\nTo find your user ID, check:")
-                print("  defaults read com.kakao.KakaoTalkMac")
-                throw ExitCode.failure
+                let detected = try DeviceInfo.userId()
+                uid = detected
+                print("User ID: \(detected)")
+            } catch {
+                uid = nil
+                let candidates = DeviceInfo.candidateUserIds()
+                print("User ID: auto-detection failed")
+                if !candidates.isEmpty {
+                    print("  Candidates from AlertKakaoIDsList: \(candidates.map(String.init).joined(separator: ", "))")
+                }
             }
         }
-        print("User ID: \(uid)")
 
-        // 3. Derive database name and key
-        let dbName = KeyDerivation.databaseName(userId: uid, uuid: deviceUUID)
-        let secureKey = KeyDerivation.secureKey(userId: uid, uuid: deviceUUID)
-
-        if verbose {
+        // 3. Show derived values if we have a userId
+        if let uid, verbose {
+            let dbName = KeyDerivation.databaseName(userId: uid, uuid: deviceUUID)
+            let secureKey = KeyDerivation.secureKey(userId: uid, uuid: deviceUUID)
             print("Database name: \(dbName)")
             print("Secure key: \(secureKey.prefix(16))...")
         }
 
-        // 4. Check if database file exists (try without extension first, then with .db)
-        let candidates = [
-            "\(DeviceInfo.containerPath)/\(dbName)",
-            "\(DeviceInfo.containerPath)/\(dbName).db",
-        ]
-        guard let dbPath = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
-            print("Database NOT found at: \(DeviceInfo.containerPath)/\(dbName)[.db]")
-            print("\nListing files in container:")
-            let containerURL = URL(fileURLWithPath: DeviceInfo.containerPath)
-            if let files = try? FileManager.default.contentsOfDirectory(at: containerURL, includingPropertiesForKeys: nil) {
-                for file in files where !file.lastPathComponent.hasSuffix("-shm") && !file.lastPathComponent.hasSuffix("-wal") {
-                    print("  \(file.lastPathComponent)")
-                }
-            } else {
-                print("  Could not list directory (check Full Disk Access)")
+        // 4. Discover database file
+        let discoveredDb = DeviceInfo.discoverDatabaseFile()
+        if let discoveredDb {
+            let name = (discoveredDb as NSString).lastPathComponent
+            print("Discovered DB: \(name)")
+        }
+
+        // 5. Try to find working userId + key combination
+        if let uid {
+            let dbName = KeyDerivation.databaseName(userId: uid, uuid: deviceUUID)
+            let candidates = [
+                "\(DeviceInfo.containerPath)/\(dbName)",
+                "\(DeviceInfo.containerPath)/\(dbName).db",
+            ]
+            if let dbPath = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) {
+                print("Database found: \(dbPath)")
+                let secureKey = KeyDerivation.secureKey(userId: uid, uuid: deviceUUID)
+                try verifyDatabase(path: dbPath, key: secureKey)
+                return
+            } else if verbose {
+                print("Derived DB name does not match any file")
             }
+        }
+
+        // 6. Try discovered DB with candidate userIds
+        if let discoveredDb {
+            let candidateIds: [Int]
+            if let uid {
+                candidateIds = [uid] + DeviceInfo.candidateUserIds().filter { $0 != uid }
+            } else {
+                candidateIds = DeviceInfo.candidateUserIds()
+            }
+
+            if !candidateIds.isEmpty {
+                print("\nTrying candidate user IDs against discovered DB...")
+                for candidate in candidateIds {
+                    let candidateKey = KeyDerivation.secureKey(userId: candidate, uuid: deviceUUID)
+                    let reader = DatabaseReader(databasePath: discoveredDb)
+                    if reader.tryOpen(key: candidateKey) {
+                        print("  userId=\(candidate): OK")
+                        let tables = try reader.schema()
+                        print("\nDatabase opened successfully with userId=\(candidate)!")
+                        print("Tables found: \(tables.count)")
+                        for table in tables {
+                            print("  - \(table.name)")
+                        }
+                        reader.close()
+                        return
+                    } else {
+                        if verbose {
+                            print("  userId=\(candidate): key mismatch")
+                        }
+                    }
+                }
+            }
+
+            // None of the candidate keys worked
+            print("\nNo candidate user ID produced a valid key.")
+            print("The database file exists but could not be decrypted.")
+            print("\nTo provide your user ID manually:")
+            print("  kakaocli auth --user-id <YOUR_KAKAO_USER_ID>")
+            print("\nTo find your user ID, check your KakaoTalk mobile app settings")
+            print("or search your plist: defaults read com.kakao.KakaoTalkMac")
             throw ExitCode.failure
         }
-        print("Database found: \(dbPath)")
 
-        // 5. Try opening the database
-        let reader = DatabaseReader(databasePath: dbPath)
+        // 7. No DB found at all
+        print("\nNo database file found in: \(DeviceInfo.containerPath)")
+        let containerURL = URL(fileURLWithPath: DeviceInfo.containerPath)
+        if let files = try? FileManager.default.contentsOfDirectory(at: containerURL, includingPropertiesForKeys: nil) {
+            print("Container contents:")
+            for file in files where !file.lastPathComponent.hasSuffix("-shm") && !file.lastPathComponent.hasSuffix("-wal") {
+                print("  \(file.lastPathComponent)")
+            }
+        } else {
+            print("  Could not list directory (check Full Disk Access)")
+        }
+        throw ExitCode.failure
+    }
+
+    private func verifyDatabase(path: String, key: String) throws {
+        let reader = DatabaseReader(databasePath: path)
         do {
-            try reader.open(key: secureKey)
+            try reader.open(key: key)
             let tables = try reader.schema()
             print("\nDatabase opened successfully!")
             print("Tables found: \(tables.count)")
@@ -86,7 +147,8 @@ struct AuthCommand: ParsableCommand {
             }
         } catch {
             print("\nFailed to open database: \(error)")
-            print("This may mean SQLCipher is needed. Install: brew install sqlcipher")
+            print("This may mean the key is wrong or SQLCipher is needed.")
+            print("Install SQLCipher: brew install sqlcipher")
         }
     }
 }

--- a/Sources/KakaoCLI/Commands/ChatsCommand.swift
+++ b/Sources/KakaoCLI/Commands/ChatsCommand.swift
@@ -64,18 +64,59 @@ func openDatabase(dbPath: String?, key: String?, userId userIdOverride: Int? = n
         secureKey = key
     } else {
         let uuid = try DeviceInfo.platformUUID()
-        let uid = try userIdOverride ?? DeviceInfo.userId()
-        let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
-        // Database files may or may not have .db extension
-        let candidates = [
-            "\(DeviceInfo.containerPath)/\(dbName)",
-            "\(DeviceInfo.containerPath)/\(dbName).db",
-        ]
-        guard let found = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
+
+        // Try standard path: derive userId → derive dbName → find file
+        if let uid = try? (userIdOverride ?? DeviceInfo.userId()) {
+            let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
+            let candidates = [
+                "\(DeviceInfo.containerPath)/\(dbName)",
+                "\(DeviceInfo.containerPath)/\(dbName).db",
+            ]
+            if let found = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) {
+                path = found
+                secureKey = key ?? KeyDerivation.secureKey(userId: uid, uuid: uuid)
+                let reader = DatabaseReader(databasePath: path)
+                try reader.open(key: secureKey)
+                return reader
+            }
+        }
+
+        // Fallback: scan for DB file, then try candidate userIds
+        guard let discoveredPath = DeviceInfo.discoverDatabaseFile() else {
+            let uid = try userIdOverride ?? DeviceInfo.userId()
+            let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
             throw KakaoError.databaseNotFound("\(DeviceInfo.containerPath)/\(dbName)")
         }
-        path = found
-        secureKey = key ?? KeyDerivation.secureKey(userId: uid, uuid: uuid)
+
+        // Try provided key first
+        if let key {
+            path = discoveredPath
+            secureKey = key
+        } else {
+            // Try each candidate userId to find the working key
+            let candidateIds: [Int]
+            if let override = userIdOverride {
+                candidateIds = [override]
+            } else {
+                var ids = (try? DeviceInfo.userId()).map { [$0] } ?? []
+                ids += DeviceInfo.candidateUserIds().filter { !ids.contains($0) }
+                candidateIds = ids
+            }
+
+            var foundKey: String?
+            for uid in candidateIds {
+                let candidateKey = KeyDerivation.secureKey(userId: uid, uuid: uuid)
+                let reader = DatabaseReader(databasePath: discoveredPath)
+                if reader.tryOpen(key: candidateKey) {
+                    reader.close()
+                    foundKey = candidateKey
+                    break
+                }
+            }
+
+            path = discoveredPath
+            secureKey = foundKey
+        }
     }
 
     let reader = DatabaseReader(databasePath: path)

--- a/Sources/KakaoCLI/Commands/StatusCommand.swift
+++ b/Sources/KakaoCLI/Commands/StatusCommand.swift
@@ -9,16 +9,16 @@ struct StatusCommand: ParsableCommand {
     )
 
     func run() throws {
-        // Check KakaoTalk.app
         let appPath = "/Applications/KakaoTalk.app"
         let containerExists = FileManager.default.fileExists(atPath: DeviceInfo.containerPath)
-        let plistExists = FileManager.default.fileExists(atPath: DeviceInfo.preferencesPath)
+        let globalPlistExists = FileManager.default.fileExists(atPath: DeviceInfo.preferencesPath)
+        let containerPlistExists = FileManager.default.fileExists(atPath: DeviceInfo.containerPreferencesPath)
 
         print("KakaoTalk Status")
         print("================")
         print("App installed:      \(FileManager.default.fileExists(atPath: appPath) ? "Yes" : "No")")
         print("Container exists:   \(containerExists ? "Yes" : "No")")
-        print("Preferences exist:  \(plistExists ? "Yes" : "No")")
+        print("Preferences exist:  \(globalPlistExists || containerPlistExists ? "Yes" : "No")\(containerPlistExists && !globalPlistExists ? " (container only)" : "")")
 
         // Check UUID
         do {
@@ -28,12 +28,32 @@ struct StatusCommand: ParsableCommand {
             print("Device UUID:        ERROR - \(error)")
         }
 
-        // Count .db files in container
+        // User ID detection
+        do {
+            let uid = try DeviceInfo.userId()
+            print("User ID:            \(uid)")
+        } catch {
+            let candidates = DeviceInfo.candidateUserIds()
+            if candidates.isEmpty {
+                print("User ID:            NOT FOUND")
+            } else {
+                print("User ID:            NOT FOUND (candidates: \(candidates.map(String.init).joined(separator: ", ")))")
+            }
+        }
+
+        // Database files
         if containerExists {
-            let url = URL(fileURLWithPath: DeviceInfo.containerPath)
-            let files = (try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)) ?? []
-            let dbFiles = files.filter { $0.pathExtension == "db" }
-            print("Database files:     \(dbFiles.count)")
+            let dbCount = DeviceInfo.countDatabaseFiles()
+            print("Database files:     \(dbCount)")
+            if let dbPath = DeviceInfo.discoverDatabaseFile() {
+                let dbName = (dbPath as NSString).lastPathComponent
+                print("Database name:      \(dbName)")
+            }
+        }
+
+        // Active account hash
+        if let hash = DeviceInfo.activeAccountHash() {
+            print("Account hash:       \(hash.prefix(40))...")
         }
 
         // Check permissions

--- a/Sources/KakaoCLI/Commands/SyncCommand.swift
+++ b/Sources/KakaoCLI/Commands/SyncCommand.swift
@@ -95,15 +95,42 @@ func resolveDatabasePath(dbPath: String?, key: String?) throws -> (path: String,
         return (dbPath, key)
     }
     let uuid = try DeviceInfo.platformUUID()
-    let uid = try DeviceInfo.userId()
-    let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
-    let candidates = [
-        "\(DeviceInfo.containerPath)/\(dbName)",
-        "\(DeviceInfo.containerPath)/\(dbName).db",
-    ]
-    guard let found = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
+
+    // Try standard path: derive userId → derive dbName → find file
+    if let uid = try? DeviceInfo.userId() {
+        let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
+        let candidates = [
+            "\(DeviceInfo.containerPath)/\(dbName)",
+            "\(DeviceInfo.containerPath)/\(dbName).db",
+        ]
+        if let found = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) {
+            let secureKey = key ?? KeyDerivation.secureKey(userId: uid, uuid: uuid)
+            return (found, secureKey)
+        }
+    }
+
+    // Fallback: scan for DB file, try candidate userIds for the key
+    guard let discoveredPath = DeviceInfo.discoverDatabaseFile() else {
+        let uid = try DeviceInfo.userId()
+        let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
         throw KakaoError.databaseNotFound("\(DeviceInfo.containerPath)/\(dbName)")
     }
-    let secureKey = key ?? KeyDerivation.secureKey(userId: uid, uuid: uuid)
-    return (found, secureKey)
+
+    if let key {
+        return (discoveredPath, key)
+    }
+
+    // Try candidate userIds to find a working key
+    let candidateIds = DeviceInfo.candidateUserIds()
+    for uid in candidateIds {
+        let candidateKey = KeyDerivation.secureKey(userId: uid, uuid: uuid)
+        let reader = DatabaseReader(databasePath: discoveredPath)
+        if reader.tryOpen(key: candidateKey) {
+            reader.close()
+            return (discoveredPath, candidateKey)
+        }
+    }
+
+    // Return the discovered path without a key — caller will get a decryption error
+    return (discoveredPath, nil)
 }

--- a/Sources/KakaoCore/Database/DatabaseReader.swift
+++ b/Sources/KakaoCore/Database/DatabaseReader.swift
@@ -15,36 +15,62 @@ public final class DatabaseReader: @unchecked Sendable {
     }
 
     /// Open the database. If a key is provided, attempts PRAGMA key (requires SQLCipher).
+    /// Tries cipher compatibility modes 3 and 4 (for newer KakaoTalk versions).
     public func open(key: String? = nil) throws {
         guard FileManager.default.fileExists(atPath: databasePath) else {
             throw KakaoError.databaseNotFound(databasePath)
         }
 
-        let result = sqlite3_open_v2(
-            databasePath,
-            &db,
-            SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX,
-            nil
-        )
-        guard result == SQLITE_OK else {
-            let msg = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
-            throw KakaoError.databaseOpenFailed(msg)
-        }
-
         if let key {
-            // SQLCipher compatibility mode 3 (matches KakaoTalk's encryption)
-            try exec("PRAGMA cipher_default_compatibility = 3")
-            try exec("PRAGMA KEY='\(key)'")
+            // Try compatibility mode 3 first (legacy), then 4 (newer versions)
+            let compatModes = [3, 4]
+            for compat in compatModes {
+                // Close previous attempt if any
+                if db != nil { sqlite3_close(db); db = nil }
 
-            // Verify the key works by reading a table
-            do {
-                try exec("SELECT count(*) FROM sqlite_master")
-            } catch {
-                throw KakaoError.databaseOpenFailed(
-                    "PRAGMA key failed — database is encrypted and SQLCipher may not be linked. " +
-                    "Install via: brew install sqlcipher"
+                let result = sqlite3_open_v2(
+                    databasePath, &db,
+                    SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil
                 )
+                guard result == SQLITE_OK else {
+                    let msg = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
+                    throw KakaoError.databaseOpenFailed(msg)
+                }
+
+                do {
+                    try exec("PRAGMA cipher_default_compatibility = \(compat)")
+                    try exec("PRAGMA KEY='\(key)'")
+                    try exec("SELECT count(*) FROM sqlite_master")
+                    return // success
+                } catch {
+                    continue
+                }
             }
+            throw KakaoError.databaseOpenFailed(
+                "PRAGMA key failed with all cipher compatibility modes — " +
+                "database is encrypted and key may be wrong, or SQLCipher may not be linked. " +
+                "Install via: brew install sqlcipher"
+            )
+        } else {
+            let result = sqlite3_open_v2(
+                databasePath, &db,
+                SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, nil
+            )
+            guard result == SQLITE_OK else {
+                let msg = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
+                throw KakaoError.databaseOpenFailed(msg)
+            }
+        }
+    }
+
+    /// Try opening the database with a key. Returns true if the key is valid.
+    public func tryOpen(key: String) -> Bool {
+        do {
+            try open(key: key)
+            return true
+        } catch {
+            close()
+            return false
         }
     }
 

--- a/Sources/KakaoCore/Database/DeviceInfo.swift
+++ b/Sources/KakaoCore/Database/DeviceInfo.swift
@@ -1,3 +1,4 @@
+import CommonCrypto
 import Foundation
 
 /// Extracts device UUID and KakaoTalk user ID from the local system.
@@ -50,11 +51,12 @@ public enum DeviceInfo {
 
     /// Extract user ID from the KakaoTalk preferences plist.
     ///
-    /// The user ID is embedded as a suffix in FSChatWindowTransparency keys:
-    /// `FSChatWindowTransparency<chatRoomId><userId>` — the userId is the
-    /// common suffix shared across all such keys.
+    /// Tries multiple strategies in order:
+    /// 1. FSChatWindowTransparency common suffix (legacy)
+    /// 2. Direct key lookup (userId, user_id, etc.)
+    /// 3. Recover userId by reversing SHA-512 hash from plist revision keys
+    /// 4. FSChatWindowFrame_ common suffix
     public static func userId() throws -> Int {
-        // Try container plist first, then global
         let plistPaths = [containerPreferencesPath, preferencesPath]
         for plistPath in plistPaths {
             guard FileManager.default.fileExists(atPath: plistPath) else { continue }
@@ -66,11 +68,10 @@ public enum DeviceInfo {
             }
 
             // Strategy 1: Extract common suffix from FSChatWindowTransparency keys
-            let prefix = "FSChatWindowTransparency"
-            let fsChatKeys = plist.keys.filter { $0.hasPrefix(prefix) }
+            let transparencyPrefix = "FSChatWindowTransparency"
+            let fsChatKeys = plist.keys.filter { $0.hasPrefix(transparencyPrefix) }
             if fsChatKeys.count >= 2 {
-                let suffixes = fsChatKeys.map { String($0.dropFirst(prefix.count)) }
-                // Find the longest common suffix among all keys
+                let suffixes = fsChatKeys.map { String($0.dropFirst(transparencyPrefix.count)) }
                 if let commonSuffix = longestCommonSuffix(suffixes), let id = Int(commonSuffix) {
                     return id
                 }
@@ -82,9 +83,145 @@ public enum DeviceInfo {
                 if let id = plist[key] as? Int { return id }
                 if let str = plist[key] as? String, let id = Int(str) { return id }
             }
+
+            // Strategy 3: Recover userId from SHA-512 hash in plist revision keys.
+            // Newer KakaoTalk stores SHA-512(userId) as a suffix on keys like
+            // "DESIGNATEDFRIENDSREVISION:<sha512hex>". The active account has non-zero values.
+            // We brute-force the pre-image since userIds are typically small integers.
+            if let hash = activeAccountHash(from: plist) {
+                if let id = recoverUserIdFromSHA512(hexHash: hash) {
+                    return id
+                }
+            }
+
+            // Strategy 4: FSChatWindowFrame_ common suffix (newer KakaoTalk versions)
+            let framePrefix = "NSWindow Frame FSChatWindowFrame_"
+            let frameKeys = plist.keys.filter { $0.hasPrefix(framePrefix) }
+            if frameKeys.count >= 2 {
+                let suffixes = frameKeys.map { String($0.dropFirst(framePrefix.count)) }
+                if let commonSuffix = longestCommonSuffix(suffixes), let id = Int(commonSuffix) {
+                    return id
+                }
+            }
         }
 
-        throw KakaoError.userIdNotFound(["Could not extract from FSChatWindowTransparency keys or direct lookup"])
+        throw KakaoError.userIdNotFound(["Could not extract from FSChatWindowTransparency, revision key SHA-512, or FSChatWindowFrame_ keys"])
+    }
+
+    /// Read AlertKakaoIDsList from plist as candidate user IDs.
+    public static func candidateUserIds() -> [Int] {
+        let plistPaths = [containerPreferencesPath, preferencesPath]
+        for plistPath in plistPaths {
+            guard FileManager.default.fileExists(atPath: plistPath),
+                  let data = try? Data(contentsOf: URL(fileURLWithPath: plistPath)),
+                  let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+                  let ids = plist["AlertKakaoIDsList"] as? [Any] else { continue }
+
+            return ids.compactMap { item -> Int? in
+                if let id = item as? Int { return id > 0 ? id : nil }
+                if let str = item as? String, let id = Int(str) { return id > 0 ? id : nil }
+                return nil
+            }
+        }
+        return []
+    }
+
+    /// Discover database file by scanning the container for 78-char hex filenames.
+    public static func discoverDatabaseFile() -> String? {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: containerPath) else { return nil }
+        let hexPattern = try! NSRegularExpression(pattern: "^[0-9a-f]{78}$")
+        for entry in entries {
+            let range = NSRange(entry.startIndex..., in: entry)
+            if hexPattern.firstMatch(in: entry, range: range) != nil {
+                return "\(containerPath)/\(entry)"
+            }
+        }
+        // Also check files with .db extension that have hex basename
+        let hexDbPattern = try! NSRegularExpression(pattern: "^[0-9a-f]{78}\\.db$")
+        for entry in entries {
+            let range = NSRange(entry.startIndex..., in: entry)
+            if hexDbPattern.firstMatch(in: entry, range: range) != nil {
+                return "\(containerPath)/\(entry)"
+            }
+        }
+        return nil
+    }
+
+    /// Count database files in the container (78-char hex files or .db files).
+    public static func countDatabaseFiles() -> Int {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: containerPath) else { return 0 }
+        let hexPattern = try! NSRegularExpression(pattern: "^[0-9a-f]{78}(\\.db)?$")
+        return entries.filter { entry in
+            let range = NSRange(entry.startIndex..., in: entry)
+            return hexPattern.firstMatch(in: entry, range: range) != nil
+        }.count
+    }
+
+    /// Extract the active account SHA-512 hash from plist revision keys.
+    /// Keys like `DESIGNATEDFRIENDSREVISION:<sha512hex>` appear with non-zero values for the active account.
+    /// SHA-512("0") is the default/empty account hash.
+    public static func activeAccountHash() -> String? {
+        let plistPaths = [containerPreferencesPath, preferencesPath]
+        for plistPath in plistPaths {
+            guard FileManager.default.fileExists(atPath: plistPath),
+                  let data = try? Data(contentsOf: URL(fileURLWithPath: plistPath)),
+                  let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else { continue }
+            if let hash = activeAccountHash(from: plist) {
+                return hash
+            }
+        }
+        return nil
+    }
+
+    private static func activeAccountHash(from plist: [String: Any]) -> String? {
+        // SHA-512("0") = 31bca02... is the default/empty account
+        let emptyHash = "31bca02094eb78126a517b206a88c73cfa9ec6f704c7030d18212cace820f025f00bf0ea68dbf3f3a5436ca63b53bf7bf80ad8d5de7d8359d0b7fed9dbc3ab99"
+        let prefix = "DESIGNATEDFRIENDSREVISION:"
+        for (key, val) in plist where key.hasPrefix(prefix) {
+            let hash = String(key.dropFirst(prefix.count))
+            if hash == emptyHash { continue }
+            let intVal: Int
+            if let v = val as? Int { intVal = v }
+            else if let v = val as? Double { intVal = Int(v) }
+            else { intVal = 0 }
+            if intVal != 0 { return hash }
+        }
+        return nil
+    }
+
+    /// Recover a userId by brute-forcing the SHA-512 pre-image.
+    /// KakaoTalk stores SHA-512(userId) as hex in plist keys. Since userIds are
+    /// typically small integers, this is fast (< 1 second for IDs under 1M).
+    /// Searches up to 1 billion with a 10-second timeout.
+    public static func recoverUserIdFromSHA512(hexHash: String) -> Int? {
+        guard hexHash.count == 128 else { return nil }
+        // Parse target hash to bytes
+        var targetBytes = [UInt8](repeating: 0, count: 64)
+        var hexChars = Array(hexHash)
+        for i in 0..<64 {
+            guard let byte = UInt8(String(hexChars[i*2...i*2+1]), radix: 16) else { return nil }
+            targetBytes[i] = byte
+        }
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        let maxId = 1_000_000_000
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA512_DIGEST_LENGTH))
+
+        for i in 0..<maxId {
+            let s = String(i)
+            let data = Array(s.utf8)
+            CC_SHA512(data, CC_LONG(data.count), &hash)
+            if hash == targetBytes {
+                return i
+            }
+            // Timeout after 10 seconds
+            if i % 5_000_000 == 0 && i > 0 {
+                if CFAbsoluteTimeGetCurrent() - startTime > 10 { return nil }
+            }
+        }
+        return nil
     }
 
     private static func longestCommonSuffix(_ strings: [String]) -> String? {


### PR DESCRIPTION
## Summary
- Fix userId auto-detection for recent KakaoTalk Mac versions where `FSChatWindowTransparency` plist keys no longer exist
- Newer KakaoTalk stores `SHA-512(userId)` as revision key suffixes in plist — recover the userId by brute-forcing the small integer pre-image (~2M hashes/sec, <1s for typical IDs)
- Add DB file discovery by scanning the container for 78-char hex filenames as fallback
- Try SQLCipher cipher compatibility modes 3 and 4 in sequence
- Fix `kakaocli status` to detect container-only preferences and hex DB files

## Details

### Root cause
Recent KakaoTalk Mac (including App Store version 26.2.0) removed the `FSChatWindowTransparency` keys that `DeviceInfo.userId()` relied on. Additionally, `AlertKakaoIDsList` contains friend IDs, not the user's own ID.

### How userId is now detected
1. `FSChatWindowTransparency` common suffix (legacy, still works on older versions)
2. Direct key lookup (`userId`, `user_id`, etc.)
3. **NEW**: SHA-512 pre-image recovery from plist revision keys like `DESIGNATEDFRIENDSREVISION:<sha512hex>`
4. `FSChatWindowFrame_` common suffix

### Files changed
- `Sources/KakaoCore/Database/DeviceInfo.swift` — userId fallback strategies, DB file scanning, SHA-512 recovery
- `Sources/KakaoCore/Database/DatabaseReader.swift` — multi-compatibility cipher open, `tryOpen()` method
- `Sources/KakaoCLI/Commands/StatusCommand.swift` — fix preferences and DB file reporting
- `Sources/KakaoCLI/Commands/ChatsCommand.swift` — `openDatabase()` scan fallback
- `Sources/KakaoCLI/Commands/SyncCommand.swift` — `resolveDatabasePath()` scan fallback
- `Sources/KakaoCLI/Commands/AuthCommand.swift` — improved diagnostics

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` passes (4 tests)
- [x] `kakaocli status` shows correct User ID, Preferences, DB files
- [x] `kakaocli auth --verbose` opens database successfully
- [x] `kakaocli chats` returns chat list

Closes #1, closes #2