### PR TITLE
fix: resolve chat display names from DB (NTChatMeta, displayMemberIds, NTOpenLink)

### DIFF
--- a/Sources/KakaoCore/Database/DatabaseReader.swift
+++ b/Sources/KakaoCore/Database/DatabaseReader.swift
@@ -88,21 +88,42 @@ public final class DatabaseReader: @unchecked Sendable {
         let sql = """
             SELECT r.chatId, r.type, r.chatName, r.activeMembersCount,
                    r.lastLogId, r.lastUpdatedAt, r.countOfNewMessage,
-                   u.displayName, u.friendNickName, u.nickName
+                   u.displayName, u.friendNickName, u.nickName,
+                   m.content, o.linkName, r.displayMemberIds
             FROM NTChatRoom r
             LEFT JOIN NTUser u ON r.directChatMemberUserId = u.userId AND u.linkId = 0
+            LEFT JOIN NTChatMeta m ON r.chatId = m.chatId AND m.type = 3
+            LEFT JOIN NTOpenLink o ON r.linkId = o.linkId AND r.linkId != 0
             ORDER BY r.lastUpdatedAt DESC
             LIMIT ?
             """
         return try query(sql, bind: [.int(limit)]) { row in
-            // For direct chats, use the friend's name; for groups, use chatName
             let chatName = row.string(2)
-            let displayName = row.string(7) ?? row.string(8) ?? row.string(9)
-            let name = chatName ?? displayName ?? "(unknown)"
+            let friendName = row.string(7) ?? row.string(8) ?? row.string(9)
+            let metaName = row.string(10)
+            let openLinkName = row.string(11)
+            let displayMemberIds = row.blob(12)
+
+            // Build member name for unnamed group chats
+            var memberName: String? = nil
+            if let blob = displayMemberIds, !blob.isEmpty {
+                memberName = resolveMemberNames(from: blob)
+            }
+
+            let chatType = Chat.ChatType.from(rawInt: row.int(1))
+            let isSelfChat = row.int(1) == 5
+
+            // Priority: custom name > chatName > openLink name > member names > friend name > self-chat
+            let name: String
+            if isSelfChat {
+                name = metaName ?? chatName ?? "나와의 채팅"
+            } else {
+                name = metaName ?? chatName ?? openLinkName ?? memberName ?? friendName ?? "(unknown)"
+            }
 
             return Chat(
                 id: row.int64(0),
-                type: Chat.ChatType.from(rawInt: row.int(1)),
+                type: chatType,
                 displayName: name,
                 memberCount: row.int(3),
                 lastMessageId: row.optionalInt64(4),
@@ -110,6 +131,27 @@ public final class DatabaseReader: @unchecked Sendable {
                 unreadCount: row.int(6)
             )
         }
+    }
+
+    /// Parse displayMemberIds (binary plist of user IDs) and resolve names from NTUser.
+    private func resolveMemberNames(from blob: Data) -> String? {
+        guard let plist = try? PropertyListSerialization.propertyList(from: blob, format: nil),
+              let userIds = plist as? [NSNumber], !userIds.isEmpty else {
+            return nil
+        }
+        let placeholders = userIds.map { _ in "?" }.joined(separator: ", ")
+        let sql = """
+            SELECT COALESCE(friendNickName, nickName, displayName)
+            FROM NTUser
+            WHERE linkId = 0 AND userId IN (\(placeholders))
+            """
+        let bindings = userIds.map { SQLValue.int64(Int64(truncating: $0)) }
+        guard let names: [String] = try? query(sql, bind: bindings, transform: { row in
+            row.string(0) ?? ""
+        }).filter({ !$0.isEmpty }) else {
+            return nil
+        }
+        return names.isEmpty ? nil : names.joined(separator: ", ")
     }
 
     /// Get messages for a chat, optionally filtered by time.
@@ -355,16 +397,25 @@ public final class DatabaseReader: @unchecked Sendable {
             let val = sqlite3_column_int64(stmt, col)
             return val == 0 ? nil : Date(timeIntervalSince1970: Double(val))
         }
+
+        func blob(_ col: Int32) -> Data? {
+            guard sqlite3_column_type(stmt, col) != SQLITE_NULL,
+                  let ptr = sqlite3_column_blob(stmt, col) else { return nil }
+            let size = Int(sqlite3_column_bytes(stmt, col))
+            return Data(bytes: ptr, count: size)
+        }
     }
 }
 
 extension Chat.ChatType {
     /// Map KakaoTalk's integer chat type to our enum.
     static func from(rawInt: Int) -> Self {
-        // KakaoTalk uses integer types; exact mapping TBD via testing
         switch rawInt {
         case 0: return .direct
         case 1: return .group
+        case 2: return .direct   // bot / official account
+        case 4: return .openChat
+        case 5: return .direct   // self-chat
         default: return .unknown
         }
     }


### PR DESCRIPTION
## Summary / 요약

Most group chats showed as `(unknown)` because `kakaocli chats` only checked `NTChatRoom.chatName`, which is empty for most chats.

대부분의 그룹 채팅방이 `(unknown)`으로 표시되는 문제를 수정했습니다. 기존에는 `NTChatRoom.chatName`만 확인했는데, 이 필드는 대부분의 채팅방에서 비어 있습니다.

## Changes / 변경사항

This PR adds three additional name resolution sources to `DatabaseReader.chats()`:

이 PR은 `DatabaseReader.chats()`에 세 가지 이름 해석 소스를 추가합니다:

1. **`NTChatMeta` (type=3)** — Custom group chat names set by users
   - 사용자가 지정한 그룹 채팅방 이름
2. **`displayMemberIds`** — Binary plist of member IDs, resolved to names via `NTUser`
   - 이름이 지정되지 않은 그룹 채팅방의 멤버 이름 조합
3. **`NTOpenLink`** — Open chat/channel names via `linkId`
   - 오픈채팅방 이름

### Name resolution priority / 이름 해석 우선순위:
```
NTChatMeta (custom name) > NTChatRoom.chatName > NTOpenLink.linkName > member names > friend name > "나와의 채팅" (self-chat)
```

### Also includes / 추가 변경사항:
- `Row.blob()` helper for reading BLOB columns / BLOB 컬럼 읽기 헬퍼
- Self-chat (type=5) labeled as "나와의 채팅" / 셀프 채팅 라벨
- `ChatType` mapping for bot accounts (type=2) and open chats (type=4) / 봇 계정 및 오픈채팅 타입 매핑

## Before / 이전
```
[xxx] (unknown) 10:57      ← custom-named group chat
[xxx] (unknown) 09:12      ← custom-named group chat
[xxx] (unknown) 08:33      ← custom-named group chat
[xxx] (unknown) yesterday  ← unnamed group chat (3 members)
[xxx] (unknown) yesterday  ← unnamed group chat (4 members)
[xxx] (unknown) 03/31      ← self-chat
```

## After / 이후
```
[xxx] 프로젝트 회의방 10:57           ← resolved from NTChatMeta type=3
[xxx] 팀 공지방 09:12                 ← resolved from NTChatMeta type=3
[xxx] 스터디 그룹 08:33               ← resolved from NTChatMeta type=3
[xxx] Alice, Bob yesterday            ← resolved from displayMemberIds + NTUser
[xxx] Alice, Bob, Charlie yesterday   ← resolved from displayMemberIds + NTUser
[xxx] 나와의 채팅 03/31               ← self-chat fallback label
```

## Test plan / 테스트

- [x] `swift build -c release` passes / 빌드 성공
- [x] `kakaocli chats --limit 50` — tested with 50 chats, 0 `(unknown)` / 50개 중 `(unknown)` 0개
- [x] Custom-named group chats resolved from `NTChatMeta` / 커스텀 이름 채팅방 정상 표시
- [x] Unnamed group chats show comma-separated member names / 이름 미지정 채팅방 멤버 이름 조합 표시
- [x] Open chats resolved from `NTOpenLink` / 오픈채팅방 이름 정상 표시
- [x] Self-chat shows "나와의 채팅" / 셀프 채팅 라벨 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)