### PR TITLE
fix: update chat name AXStaticText identifier from _NS:18 to _NS:40

### DIFF
--- a/Sources/KakaoCore/Automation/AXHelpers.swift
+++ b/Sources/KakaoCore/Automation/AXHelpers.swift
@@ -187,14 +187,14 @@ public enum AXHelpers {
     }
 
     /// Find the AXRow in a chat list whose name label matches the given text.
-    /// KakaoTalk chat list: AXTable > AXRow > AXCell > AXStaticText(id="_NS:18")
+    /// KakaoTalk chat list: AXTable > AXRow > AXCell > AXStaticText(id="_NS:40")
     public static func findChatRow(_ table: AXUIElement, chatName: String, exact: Bool = false) -> AXUIElement? {
         for row in children(table) {
             guard role(row) == "AXRow" else { continue }
             for cell in children(row) {
                 guard role(cell) == "AXCell" else { continue }
                 for child in children(cell) {
-                    if role(child) == "AXStaticText" && identifier(child) == "_NS:18" {
+                    if role(child) == "AXStaticText" && identifier(child) == "_NS:40" {
                         let name = value(child) ?? ""
                         let matches = exact ? name == chatName : name.localizedCaseInsensitiveContains(chatName)
                         if matches {


### PR DESCRIPTION
## Summary

`kakaocli send <chat>` failed to find any chat room by name because the AXStaticText identifier used to match chat name labels changed from `_NS:18` to `_NS:40` in a recent KakaoTalk Mac update.

## Root cause

`AXHelpers.findChatRow()` matched the chat name label with a hardcoded identifier:

```swift
identifier(child) == "_NS:18"
```

After a KakaoTalk update, the `DBTextFieldCell` element that renders chat names now reports `_NS:40` as its AX identifier. Since no element matched, `findChatRow()` always returned `nil`, causing every send to a named chat to fail with `chatNotFound`.

The `--me` path was unaffected because `findSelfChatRow()` identifies the self-chat row via the `"badge me"` AXImage descriptor, not a text identifier.

## Changes

- `Sources/KakaoCore/Automation/AXHelpers.swift`: update identifier from `_NS:18` to `_NS:40`

## Test plan

- [x] `swift build -c release` passes
- [x] `kakaocli send --dry-run "<chat name>" "<msg>"` resolves the correct row
- [x] `kakaocli send "<chat name>" "<msg>"` delivers the message successfully