### PR TITLE
fix: support newer KakaoTalk Mac composer layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,18 @@ Instructions for AI agents that want to read and send KakaoTalk messages.
 - System Settings > Privacy & Security: **Full Disk Access** + **Accessibility** granted to your terminal
 - KakaoTalk credentials stored (see First-Time Setup below)
 
+## Source of Truth
+
+- Treat `~/Repository/kakaocli-upstream` as the source of truth.
+- For this machine's OpenClaw runtime, point `~/.openclaw/openclaw.json` at the stable built binary path:
+  - `~/Repository/kakaocli-upstream/.build/arm64-apple-macosx/release/kakaocli`
+- Source edits do not affect the live OpenClaw runtime until you rebuild with `swift build -c release`.
+- After AX/send fixes, prefer this local rollout order:
+  1. `swift test -Xcc -I/opt/homebrew/include -Xlinker -L/opt/homebrew/lib`
+  2. `swift build -c release -Xcc -I/opt/homebrew/include -Xlinker -L/opt/homebrew/lib`
+  3. `./.build/release/kakaocli status`
+  4. Restart the gateway in its current mode: use `launchctl kickstart -k "gui/$(id -u)/ai.openclaw.gateway"` when `~/.openclaw/bin/openclaw-gateway-screen.py status` shows `screenRunning: false`; use `~/.openclaw/bin/openclaw-gateway-screen.py restart` only when screen mode is already active.
+
 ## First-Time Setup
 
 Before using kakaocli, store credentials so the tool can auto-login:
@@ -77,6 +89,7 @@ KakaoTalk's macOS Accessibility (AX) hierarchy is non-standard:
 - When the window is hidden (app running in menu bar), there are zero real AXWindow elements
 - The **status bar menu** is the most reliable state indicator ("Log out" present = logged in)
 - After login, the window briefly disappears during the transition — don't poll aggressively
+- Inline composers and dedicated chat windows can differ between builds, so keep message-composer detection in shared helpers rather than duplicating it per command
 
 ## Quick Start
 
@@ -95,6 +108,9 @@ kakaocli send "Mom" "I'll be home soon"
 
 # Send to self-chat (for testing — ALWAYS use this for tests)
 kakaocli send x --me "Test message"
+
+# Preview leaving a chatroom
+kakaocli leave --dry-run "Test Room"
 
 # Watch for new messages (NDJSON stream)
 kakaocli sync --follow
@@ -134,6 +150,18 @@ kakaocli send "Mom" "Hello" --dry-run       # Preview without sending
 - Rate limit: wait at least 2 seconds between sends
 - The chat window opens, types, sends, then closes automatically
 - The `--me` flag sends to self-chat regardless of the chat name argument (use `_` as placeholder)
+
+## Leaving Chatrooms
+
+```bash
+kakaocli leave --dry-run "Chat Name"   # Preview without leaving
+kakaocli leave "Chat Name"             # Leave a chatroom via the KakaoTalk menu
+```
+
+**Important constraints:**
+- This is destructive for that KakaoTalk account; use `--dry-run` before testing.
+- UI automation needs Accessibility permission granted to your terminal or runtime binary.
+- Do not run actual leave tests against shared rooms unless the user explicitly asks.
 
 ## Sync Mode (Real-Time Monitoring)
 
@@ -238,7 +266,7 @@ Returns JSON array with per-chat results:
 ## Safety Rules
 
 1. **Never send test messages to other people's chats.** Use `--me` flag for testing.
-2. **Always use `--dry-run` first** when testing new send logic.
+2. **Always use `--dry-run` first** when testing new send or leave logic.
 3. **Rate limit sends** — at least 2 seconds between messages.
 4. **Respect hours** — avoid sending between 11 PM and 7 AM unless urgent.
-5. **Confirm before sending** — agents should verify message content with the user before sending to others.
+5. **Confirm before sending or leaving** — agents should verify message content or room names with the user before acting on other people's chats.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@ swift test
 ```
 
 No external dependencies besides `sqlcipher` (Homebrew). The `CSQLCipher` system library target wraps it via pkg-config.
+On this Mac mini, `pkg-config` may be absent even though Homebrew `sqlcipher` is installed. In that case use explicit link flags:
+
+```bash
+swift test -Xcc -I/opt/homebrew/opt/sqlcipher/include -Xlinker -L/opt/homebrew/opt/sqlcipher/lib -Xlinker -lsqlcipher -Xlinker -rpath -Xlinker /opt/homebrew/opt/sqlcipher/lib
+swift build -c release -Xcc -I/opt/homebrew/opt/sqlcipher/include -Xlinker -L/opt/homebrew/opt/sqlcipher/lib -Xlinker -lsqlcipher -Xlinker -rpath -Xlinker /opt/homebrew/opt/sqlcipher/lib
+```
 
 ## Project Structure
 
@@ -71,6 +77,10 @@ No external dependencies besides `sqlcipher` (Homebrew). The `CSQLCipher` system
 ### Query Command
 - `kakaocli query "SELECT ..."` — runs raw read-only SQL against the decrypted DB, returns JSON array of arrays.
 - Useful for ad-hoc data extraction (e.g., member lists, message stats, schema exploration).
+
+### Sync Command
+- `kakaocli sync --group-mention-tag @클로` emits direct-chat messages normally but only emits group-chat messages that start with that mention tag. This keeps unmentioned group text out of the OpenClaw Node bridge stream.
+- The mention tag option may be repeated. Prefix matching accepts the exact tag alone or followed by whitespace, comma, colon, or dash.
 
 ### Debugging UI Automation
 - **Use `peekaboo` for screenshots**: `peekaboo image --window-id <ID> --no-remote --path /tmp/debug.png`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ kakaocli lets AI agents (Claude Code, Cursor, custom bots) check and send your K
 - **AI Agent Integration** — JSON output for every command, MCP skill definition, webhook delivery, auto-login
 - **Read** — list chats, view messages, full-text search, raw SQL queries
 - **Send** — send messages to any chat via UI automation
+- **Leave** — leave a chatroom via UI automation
 - **Sync** — real-time NDJSON message stream with webhook support
 - **Harvest** — bulk-capture chat names and load older message history
 
@@ -38,6 +39,7 @@ kakaocli는 AI 에이전트(Claude Code, Cursor, 커스텀 봇)가 카카오톡 
 - **AI 에이전트 연동** — 모든 명령의 JSON 출력, MCP 스킬 정의, 웹훅 전달, 자동 로그인
 - **읽기** — 채팅 목록, 메시지 조회, 전체 텍스트 검색, SQL 쿼리
 - **전송** — UI 자동화를 통한 메시지 전송
+- **나가기** — UI 자동화를 통한 채팅방 나가기
 - **동기화** — 실시간 NDJSON 메시지 스트림 및 웹훅 지원
 - **수집** — 채팅방 이름 일괄 수집 및 이전 메시지 로드
 
@@ -81,7 +83,7 @@ Your terminal app needs two permissions in **System Settings > Privacy & Securit
 - **Accessibility** (접근성) — for UI automation (sending messages, harvest)
 
 > [!NOTE]
-> Full Disk Access is required for all commands. Accessibility is only needed for `send`, `harvest`, and `inspect`.
+> Full Disk Access is required for all commands. Accessibility is only needed for `send`, `leave`, `harvest`, and `inspect`.
 
 ### 3. Verify it works / 동작 확인
 
@@ -114,6 +116,9 @@ kakaocli send "지수" "안녕!"
 
 # Send to self-chat (나와의 채팅) — safe for testing
 kakaocli send --me _ "test message"
+
+# Leave a chatroom (destructive; use --dry-run first)
+kakaocli leave --dry-run "테스트방"
 
 # Stream new messages as JSON
 kakaocli sync --follow
@@ -149,6 +154,13 @@ All read commands support `--json` for structured output.
 kakaocli send "chat name" "message"    # Send to a chat
 kakaocli send --me _ "message"         # Send to self-chat (나와의 채팅)
 kakaocli send --dry-run "name" "msg"   # Preview without sending
+```
+
+### Leave / 나가기
+
+```bash
+kakaocli leave --dry-run "chat name"   # Preview without leaving
+kakaocli leave "chat name"             # Leave a chatroom
 ```
 
 ### Sync / 동기화

--- a/Sources/KakaoCLI/Commands/ChatsCommand.swift
+++ b/Sources/KakaoCLI/Commands/ChatsCommand.swift
@@ -20,8 +20,11 @@ struct ChatsCommand: ParsableCommand {
     @Option(name: .long, help: "Database encryption key (auto-derived if not set)")
     var key: String?
 
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
-        let reader = try openDatabase(dbPath: db, key: key)
+        let reader = try openDatabase(dbPath: db, key: key, userId: userId)
         defer { reader.close() }
 
         let chats = try reader.chats(limit: limit)

--- a/Sources/KakaoCLI/Commands/InspectCommand.swift
+++ b/Sources/KakaoCLI/Commands/InspectCommand.swift
@@ -33,7 +33,10 @@ struct InspectCommand: ParsableCommand {
                 print("Could not find main window")
                 throw ExitCode.failure
             }
-            if let chatroomsTab = AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") {
+            let chatroomsTab =
+                AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") ??
+                AXHelpers.findFirst(mainWindow, role: "AXButton", identifier: "chatrooms")
+            if let chatroomsTab {
                 _ = AXHelpers.performAction(chatroomsTab, kAXPressAction as String)
                 Thread.sleep(forTimeInterval: 0.3)
             }

--- a/Sources/KakaoCLI/Commands/InspectCommand.swift
+++ b/Sources/KakaoCLI/Commands/InspectCommand.swift
@@ -33,6 +33,20 @@ struct InspectCommand: ParsableCommand {
                 print("Could not find main window")
                 throw ExitCode.failure
             }
+            func waitForConversationOpen(timeout: TimeInterval = 2.0) -> Bool {
+                let deadline = Date().addingTimeInterval(timeout)
+                while Date() < deadline {
+                    Thread.sleep(forTimeInterval: 0.25)
+                    let updatedWindows = AXHelpers.windows(app)
+                    if updatedWindows.contains(where: { AXHelpers.identifier($0) != "Main Window" }) {
+                        return true
+                    }
+                    if AXHelpers.findMessageComposer(in: mainWindow) != nil {
+                        return true
+                    }
+                }
+                return false
+            }
             let chatroomsTab =
                 AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") ??
                 AXHelpers.findFirst(mainWindow, role: "AXButton", identifier: "chatrooms")
@@ -42,9 +56,37 @@ struct InspectCommand: ParsableCommand {
             }
             if let table = AXHelpers.chatListTable(mainWindow) {
                 if let row = AXHelpers.findChatRow(table, chatName: chatName) {
-                    print("Found chat: \(chatName), double-clicking to open...")
-                    AXHelpers.doubleClickElement(row)
-                    Thread.sleep(forTimeInterval: 1.0)
+                    print("Found chat: \(chatName), opening...")
+                    var opened = false
+                    if AXHelpers.selectRow(row, in: table) {
+                        Thread.sleep(forTimeInterval: 0.2)
+                        AXHelpers.pressKey(keyCode: 36)
+                        opened = waitForConversationOpen()
+                    }
+                    if !opened {
+                        AXHelpers.clickElement(row)
+                        Thread.sleep(forTimeInterval: 0.2)
+                        AXHelpers.pressKey(keyCode: 36)
+                        opened = waitForConversationOpen()
+                    }
+                    if !opened,
+                       let nameLabel = AXHelpers.findFirst(row, role: "AXStaticText", text: chatName, maxDepth: 4) {
+                        AXHelpers.doubleClickElement(nameLabel)
+                        opened = waitForConversationOpen()
+                    }
+                    if !opened,
+                       let cell = AXHelpers.children(row).first(where: { AXHelpers.role($0) == "AXCell" }) {
+                        AXHelpers.doubleClickElement(cell)
+                        opened = waitForConversationOpen()
+                    }
+                    if !opened {
+                        if let scrollArea = AXHelpers.chatListScrollArea(mainWindow) {
+                            _ = AXHelpers.scrollRowToVisible(row, in: scrollArea)
+                            Thread.sleep(forTimeInterval: 0.3)
+                        }
+                        AXHelpers.doubleClickElement(row)
+                        opened = waitForConversationOpen(timeout: 5.0)
+                    }
                 } else {
                     print("Chat '\(chatName)' not found in chat list")
                     throw ExitCode.failure
@@ -52,6 +94,9 @@ struct InspectCommand: ParsableCommand {
             }
             // Re-fetch windows after opening chat
             let updatedWindows = AXHelpers.windows(app)
+            if AXHelpers.findMessageComposer(in: mainWindow) != nil {
+                print("Detected inline composer in Main Window.")
+            }
             for (i, window) in updatedWindows.enumerated() {
                 let title = AXHelpers.title(window) ?? "(untitled)"
                 print("=== Window \(i): \(title) ===")

--- a/Sources/KakaoCLI/Commands/LeaveCommand.swift
+++ b/Sources/KakaoCLI/Commands/LeaveCommand.swift
@@ -1,0 +1,27 @@
+import ArgumentParser
+import Foundation
+import KakaoCore
+
+struct LeaveCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "leave",
+        abstract: "Leave a KakaoTalk chatroom via UI automation"
+    )
+
+    @Argument(help: "Chat name to leave (substring match)")
+    var chat: String
+
+    @Flag(name: .long, help: "Show what would happen without actually leaving")
+    var dryRun = false
+
+    func run() throws {
+        if dryRun {
+            print("DRY RUN: Would leave chatroom '\(chat)'")
+            print("Steps: activate KakaoTalk -> find chat '\(chat)' -> open menu -> Leave chatroom -> confirm")
+            return
+        }
+        try AutomationPermissions.requireForSend()
+        try KakaoAutomator().leaveChat(to: chat)
+        print("Left chatroom '\(chat)'.")
+    }
+}

--- a/Sources/KakaoCLI/Commands/LeaveCommand.swift
+++ b/Sources/KakaoCLI/Commands/LeaveCommand.swift
@@ -8,20 +8,125 @@ struct LeaveCommand: ParsableCommand {
         abstract: "Leave a KakaoTalk chatroom via UI automation"
     )
 
-    @Argument(help: "Chat name to leave (substring match)")
+    @Argument(help: "Chat name to leave (substring match) or numeric chat ID")
     var chat: String
 
     @Flag(name: .long, help: "Show what would happen without actually leaving")
     var dryRun = false
 
+    @Option(name: .long, help: "Path to database file (auto-detected when chat is numeric)")
+    var db: String?
+
+    @Option(name: .long, help: "Database encryption key (auto-derived when chat is numeric)")
+    var key: String?
+
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
+        let automator = KakaoAutomator()
+        let targetDescription: String
+        let leaveAction: () throws -> Void
+
+        if let chatId = parseNumericChatId(chat) {
+            let target = try resolveChatIdTarget(chatId)
+            targetDescription = target.description
+            leaveAction = {
+                if let exactChatName = target.exactChatName {
+                    try automator.leaveChat(to: exactChatName)
+                } else {
+                    try automator.leaveChat(atChatIndex: target.rowIndex, targetDescription: target.description)
+                }
+            }
+        } else {
+            targetDescription = chat
+            leaveAction = {
+                try automator.leaveChat(to: chat)
+            }
+        }
+
         if dryRun {
-            print("DRY RUN: Would leave chatroom '\(chat)'")
-            print("Steps: activate KakaoTalk -> find chat '\(chat)' -> open menu -> Leave chatroom -> confirm")
+            print("DRY RUN: Would leave chatroom '\(targetDescription)'")
+            print("Steps: activate KakaoTalk -> find chat '\(targetDescription)' -> open menu -> Leave chatroom -> confirm")
             return
         }
+
         try AutomationPermissions.requireForSend()
-        try KakaoAutomator().leaveChat(to: chat)
-        print("Left chatroom '\(chat)'.")
+        try leaveAction()
+        print("Left chatroom '\(targetDescription)'.")
+    }
+
+    private struct ChatIdTarget {
+        let rowIndex: Int
+        let description: String
+        let exactChatName: String?
+    }
+
+    private func parseNumericChatId(_ value: String) -> Int64? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.unicodeScalars.allSatisfy({ CharacterSet.decimalDigits.contains($0) }) else {
+            return nil
+        }
+        return Int64(trimmed)
+    }
+
+    private func resolveChatIdTarget(_ chatId: Int64) throws -> ChatIdTarget {
+        let (path, secureKey) = try resolveDatabasePath(dbPath: db, key: key, userId: userId)
+        let reader = DatabaseReader(databasePath: path)
+        try reader.open(key: secureKey)
+        defer { reader.close() }
+
+        let metadata = MetadataStore()
+        let chats = try reader.chats(limit: 1000)
+        guard let rowIndex = chats.firstIndex(where: { $0.id == chatId }) else {
+            throw AutomationError.chatNotFound("\(chatId)")
+        }
+        let chat = chats[rowIndex]
+        let exactChatName = resolveExactChatName(
+            chat: chat,
+            chatId: chatId,
+            reader: reader,
+            metadata: metadata
+        )
+        let description = exactChatName.map { "\($0) [\(chatId)]" } ?? "\(chatId)"
+        return ChatIdTarget(
+            rowIndex: rowIndex,
+            description: description,
+            exactChatName: exactChatName
+        )
+    }
+
+    private func resolveExactChatName(
+        chat: Chat,
+        chatId: Int64,
+        reader: DatabaseReader,
+        metadata: MetadataStore
+    ) -> String? {
+        let knownName = preferredChatDisplayName(for: chat, metadata: metadata)
+        if !isUnknownChatDisplayName(knownName) {
+            return knownName
+        }
+        do {
+            let options = ChatHarvester.Options(
+                maxChats: 0,
+                namesOnly: true,
+                skipUnread: false
+            )
+            _ = try ChatHarvester.harvest(
+                db: reader,
+                metadata: metadata,
+                options: options,
+                progress: { _ in }
+            )
+            try metadata.save()
+        } catch {
+            return nil
+        }
+        let refreshedName = preferredChatDisplayName(
+            databaseDisplayName: chat.displayName,
+            metadataDisplayName: metadata.name(for: chatId)
+        )
+        return isUnknownChatDisplayName(refreshedName) ? nil : refreshedName
     }
 }

--- a/Sources/KakaoCLI/Commands/MessagesCommand.swift
+++ b/Sources/KakaoCLI/Commands/MessagesCommand.swift
@@ -29,8 +29,11 @@ struct MessagesCommand: ParsableCommand {
     @Option(name: .long, help: "Database encryption key")
     var key: String?
 
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
-        let reader = try openDatabase(dbPath: db, key: key)
+        let reader = try openDatabase(dbPath: db, key: key, userId: userId)
         defer { reader.close() }
 
         // Resolve chat name to ID if needed

--- a/Sources/KakaoCLI/Commands/QueryCommand.swift
+++ b/Sources/KakaoCLI/Commands/QueryCommand.swift
@@ -17,8 +17,11 @@ struct QueryCommand: ParsableCommand {
     @Option(name: .long, help: "Database encryption key")
     var key: String?
 
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
-        let reader = try openDatabase(dbPath: db, key: key)
+        let reader = try openDatabase(dbPath: db, key: key, userId: userId)
         defer { reader.close() }
 
         let results = try reader.rawQuery(sql)

--- a/Sources/KakaoCLI/Commands/SchemaCommand.swift
+++ b/Sources/KakaoCLI/Commands/SchemaCommand.swift
@@ -14,8 +14,11 @@ struct SchemaCommand: ParsableCommand {
     @Option(name: .long, help: "Database encryption key")
     var key: String?
 
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
-        let reader = try openDatabase(dbPath: db, key: key)
+        let reader = try openDatabase(dbPath: db, key: key, userId: userId)
         defer { reader.close() }
 
         let tables = try reader.schema()

--- a/Sources/KakaoCLI/Commands/SearchCommand.swift
+++ b/Sources/KakaoCLI/Commands/SearchCommand.swift
@@ -23,8 +23,11 @@ struct SearchCommand: ParsableCommand {
     @Option(name: .long, help: "Database encryption key")
     var key: String?
 
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
-        let reader = try openDatabase(dbPath: db, key: key)
+        let reader = try openDatabase(dbPath: db, key: key, userId: userId)
         defer { reader.close() }
 
         let results = try reader.search(query: query, limit: limit)

--- a/Sources/KakaoCLI/Commands/SendCommand.swift
+++ b/Sources/KakaoCLI/Commands/SendCommand.swift
@@ -28,6 +28,7 @@ struct SendCommand: ParsableCommand {
             print("Steps: activate KakaoTalk → find chat '\(target)' → type message → press Enter")
             return
         }
+        try AutomationPermissions.requireForSend()
         try automator.sendMessage(to: chat, message: message, selfChat: selfChat)
         print("Message sent to '\(target)'.")
     }

--- a/Sources/KakaoCLI/Commands/SendCommand.swift
+++ b/Sources/KakaoCLI/Commands/SendCommand.swift
@@ -20,6 +20,15 @@ struct SendCommand: ParsableCommand {
     @Flag(name: .long, help: "Show what would happen without actually sending")
     var dryRun = false
 
+    @Option(name: .long, help: "Path to database file (auto-detected when chat is numeric)")
+    var db: String?
+
+    @Option(name: .long, help: "Database encryption key (auto-derived when chat is numeric)")
+    var key: String?
+
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
     func run() throws {
         let automator = KakaoAutomator()
         let target = selfChat ? "self-chat" : chat
@@ -29,7 +38,48 @@ struct SendCommand: ParsableCommand {
             return
         }
         try AutomationPermissions.requireForSend()
-        try automator.sendMessage(to: chat, message: message, selfChat: selfChat)
+        if !selfChat, let chatId = parseNumericChatId(chat) {
+            let chatTarget = try resolveChatIdTarget(chatId)
+            try automator.sendMessage(
+                toChatAtIndex: chatTarget.rowIndex,
+                targetDescription: chatTarget.description,
+                message: message
+            )
+        } else {
+            try automator.sendMessage(to: chat, message: message, selfChat: selfChat)
+        }
         print("Message sent to '\(target)'.")
+    }
+
+    private struct ChatIdTarget {
+        let rowIndex: Int
+        let description: String
+    }
+
+    private func parseNumericChatId(_ value: String) -> Int64? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.unicodeScalars.allSatisfy({ CharacterSet.decimalDigits.contains($0) }) else {
+            return nil
+        }
+        return Int64(trimmed)
+    }
+
+    private func resolveChatIdTarget(_ chatId: Int64) throws -> ChatIdTarget {
+        let (path, secureKey) = try resolveDatabasePath(dbPath: db, key: key, userId: userId)
+        let reader = DatabaseReader(databasePath: path)
+        try reader.open(key: secureKey)
+        defer { reader.close() }
+
+        let chats = try reader.chats(limit: 1000)
+        guard let rowIndex = chats.firstIndex(where: { $0.id == chatId }) else {
+            throw AutomationError.chatNotFound("\(chatId)")
+        }
+        let chat = chats[rowIndex]
+        let name = chat.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let description = name.isEmpty || name == "(unknown)"
+            ? "\(chatId)"
+            : "\(name) [\(chatId)]"
+        return ChatIdTarget(rowIndex: rowIndex, description: description)
     }
 }

--- a/Sources/KakaoCLI/Commands/StatusCommand.swift
+++ b/Sources/KakaoCLI/Commands/StatusCommand.swift
@@ -13,9 +13,11 @@ struct StatusCommand: ParsableCommand {
         let containerExists = FileManager.default.fileExists(atPath: DeviceInfo.containerPath)
         let globalPlistExists = FileManager.default.fileExists(atPath: DeviceInfo.preferencesPath)
         let containerPlistExists = FileManager.default.fileExists(atPath: DeviceInfo.containerPreferencesPath)
+        let permissionReport = AutomationPermissions.report()
 
         print("KakaoTalk Status")
         print("================")
+        print("Binary path:        \(permissionReport.binaryPath)")
         print("App installed:      \(FileManager.default.fileExists(atPath: appPath) ? "Yes" : "No")")
         print("Container exists:   \(containerExists ? "Yes" : "No")")
         print("Preferences exist:  \(globalPlistExists || containerPlistExists ? "Yes" : "No")\(containerPlistExists && !globalPlistExists ? " (container only)" : "")")
@@ -61,6 +63,11 @@ struct StatusCommand: ParsableCommand {
         print("-----------")
         let hasFullDisk = containerExists && FileManager.default.isReadableFile(atPath: DeviceInfo.containerPath)
         print("Full Disk Access:   \(hasFullDisk ? "Likely OK" : "May be needed")")
+        print("Accessibility:      \(permissionReport.accessibilityTrusted ? "Granted" : "Not granted")")
+        print("System Events:      \(permissionReport.systemEventsAutomation.label)")
+        if let details = permissionReport.systemEventsAutomation.details, !details.isEmpty {
+            print("  Detail:           \(details)")
+        }
 
         // App lifecycle
         print("\nApp Lifecycle")

--- a/Sources/KakaoCLI/Commands/SyncCommand.swift
+++ b/Sources/KakaoCLI/Commands/SyncCommand.swift
@@ -29,7 +29,7 @@ struct SyncCommand: ParsableCommand {
     @Option(name: .long, help: "Override user ID instead of reading from plist")
     var userId: Int?
 
-    @Option(name: .long, help: "Only emit group chat messages that start with this mention tag; direct chats are unaffected. May be repeated.")
+    @Option(name: .long, help: "Only emit group chat messages that contain this mention tag; direct chats are unaffected. May be repeated.")
     var groupMentionTag: [String] = []
 
     func run() throws {

--- a/Sources/KakaoCLI/Commands/SyncCommand.swift
+++ b/Sources/KakaoCLI/Commands/SyncCommand.swift
@@ -26,8 +26,17 @@ struct SyncCommand: ParsableCommand {
     @Option(name: .long, help: "Database encryption key")
     var key: String?
 
+    @Option(name: .long, help: "Override user ID instead of reading from plist")
+    var userId: Int?
+
+    @Option(name: .long, help: "Only emit group chat messages that start with this mention tag; direct chats are unaffected. May be repeated.")
+    var groupMentionTag: [String] = []
+
     func run() throws {
-        let (path, secureKey) = try resolveDatabasePath(dbPath: db, key: key)
+        let (path, secureKey) = try resolveDatabasePath(dbPath: db, key: key, userId: userId)
+        let groupMentionTags = groupMentionTag
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
 
         if !follow && webhook == nil {
             // One-shot: show current high-water mark
@@ -51,7 +60,8 @@ struct SyncCommand: ParsableCommand {
             databasePath: path,
             key: secureKey,
             pollInterval: interval,
-            startFromLogId: sinceLogId
+            startFromLogId: sinceLogId,
+            groupMentionTags: groupMentionTags
         )
 
         // Handle Ctrl-C gracefully
@@ -61,6 +71,10 @@ struct SyncCommand: ParsableCommand {
         }
 
         fputs("Watching for new messages (poll every \(interval)s)...\n", stderr)
+        if !groupMentionTags.isEmpty {
+            let filterDescription = groupMentionTags.joined(separator: ", ")
+            fputs("Group mention filter: \(filterDescription)\n", stderr)
+        }
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
@@ -90,14 +104,14 @@ struct SyncCommand: ParsableCommand {
 }
 
 /// Resolve database path and key without opening the database.
-func resolveDatabasePath(dbPath: String?, key: String?) throws -> (path: String, key: String?) {
+func resolveDatabasePath(dbPath: String?, key: String?, userId userIdOverride: Int? = nil) throws -> (path: String, key: String?) {
     if let dbPath {
         return (dbPath, key)
     }
     let uuid = try DeviceInfo.platformUUID()
 
     // Try standard path: derive userId → derive dbName → find file
-    if let uid = try? DeviceInfo.userId() {
+    if let uid = try? (userIdOverride ?? DeviceInfo.userId()) {
         let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
         let candidates = [
             "\(DeviceInfo.containerPath)/\(dbName)",
@@ -111,7 +125,7 @@ func resolveDatabasePath(dbPath: String?, key: String?) throws -> (path: String,
 
     // Fallback: scan for DB file, try candidate userIds for the key
     guard let discoveredPath = DeviceInfo.discoverDatabaseFile() else {
-        let uid = try DeviceInfo.userId()
+        let uid = try userIdOverride ?? DeviceInfo.userId()
         let dbName = KeyDerivation.databaseName(userId: uid, uuid: uuid)
         throw KakaoError.databaseNotFound("\(DeviceInfo.containerPath)/\(dbName)")
     }
@@ -121,8 +135,14 @@ func resolveDatabasePath(dbPath: String?, key: String?) throws -> (path: String,
     }
 
     // Try candidate userIds to find a working key
-    var candidateIds = (try? DeviceInfo.userId()).map { [$0] } ?? [Int]()
-    candidateIds += DeviceInfo.candidateUserIds().filter { !candidateIds.contains($0) }
+    let candidateIds: [Int]
+    if let override = userIdOverride {
+        candidateIds = [override]
+    } else {
+        var ids = (try? DeviceInfo.userId()).map { [$0] } ?? [Int]()
+        ids += DeviceInfo.candidateUserIds().filter { !ids.contains($0) }
+        candidateIds = ids
+    }
     for uid in candidateIds {
         let candidateKey = KeyDerivation.secureKey(userId: uid, uuid: uuid)
         let reader = DatabaseReader(databasePath: discoveredPath)

--- a/Sources/KakaoCLI/KakaoCLI.swift
+++ b/Sources/KakaoCLI/KakaoCLI.swift
@@ -11,6 +11,7 @@ struct KakaoCLI: ParsableCommand {
             ChatsCommand.self,
             HarvestCommand.self,
             InspectCommand.self,
+            LeaveCommand.self,
             LoginCommand.self,
             MessagesCommand.self,
             QueryCommand.self,

--- a/Sources/KakaoCore/Automation/AXHelpers.swift
+++ b/Sources/KakaoCore/Automation/AXHelpers.swift
@@ -187,19 +187,25 @@ public enum AXHelpers {
     }
 
     /// Find the AXRow in a chat list whose name label matches the given text.
-    /// KakaoTalk chat list: AXTable > AXRow > AXCell > AXStaticText(id="_NS:18")
+    /// Older/newer KakaoTalk builds vary between AXTable and AXOutline and may
+    /// expose the visible name as "_NS:18", "Display Name", or a plain static text.
     public static func findChatRow(_ table: AXUIElement, chatName: String, exact: Bool = false) -> AXUIElement? {
         for row in children(table) {
             guard role(row) == "AXRow" else { continue }
             for cell in children(row) {
                 guard role(cell) == "AXCell" else { continue }
                 for child in children(cell) {
-                    if role(child) == "AXStaticText" && identifier(child) == "_NS:18" {
-                        let name = value(child) ?? ""
-                        let matches = exact ? name == chatName : name.localizedCaseInsensitiveContains(chatName)
-                        if matches {
-                            return row
-                        }
+                    guard role(child) == "AXStaticText" else { continue }
+                    let name = value(child) ?? title(child) ?? ""
+                    let id = identifier(child) ?? ""
+                    let likelyDisplayName =
+                        id == "_NS:18" ||
+                        id == "Display Name" ||
+                        (!name.isEmpty && id != "_NS:73" && id != "_NS:93")
+                    guard likelyDisplayName else { continue }
+                    let matches = exact ? name == chatName : name.localizedCaseInsensitiveContains(chatName)
+                    if matches {
+                        return row
                     }
                 }
             }
@@ -269,13 +275,14 @@ public enum AXHelpers {
         return false
     }
 
-    /// Get the AXTable (chat list) from the main window.
+    /// Get the chat list container from the main window.
+    /// KakaoTalk currently exposes this as AXTable on some builds and AXOutline on others.
     public static func chatListTable(_ window: AXUIElement) -> AXUIElement? {
-        // Structure: AXWindow > AXScrollArea > AXTable
+        // Structure: AXWindow > AXScrollArea > AXTable/AXOutline
         for child in children(window) {
             if role(child) == "AXScrollArea" {
                 for subchild in children(child) {
-                    if role(subchild) == "AXTable" {
+                    if role(subchild) == "AXTable" || role(subchild) == "AXOutline" {
                         return subchild
                     }
                 }
@@ -289,7 +296,7 @@ public enum AXHelpers {
         for child in children(window) {
             if role(child) == "AXScrollArea" {
                 for subchild in children(child) {
-                    if role(subchild) == "AXTable" {
+                    if role(subchild) == "AXTable" || role(subchild) == "AXOutline" {
                         return child
                     }
                 }

--- a/Sources/KakaoCore/Automation/AXHelpers.swift
+++ b/Sources/KakaoCore/Automation/AXHelpers.swift
@@ -232,6 +232,12 @@ public enum AXHelpers {
     /// Older/newer KakaoTalk builds vary between AXTable and AXOutline and may
     /// expose the visible name as "_NS:18", "Display Name", or a plain static text.
     public static func findChatRow(_ table: AXUIElement, chatName: String, exact: Bool = false) -> AXUIElement? {
+        findChatRows(table, chatName: chatName, exact: exact).first
+    }
+
+    /// Find all AXRows in a chat list whose visible name label matches the given text.
+    public static func findChatRows(_ table: AXUIElement, chatName: String, exact: Bool = false) -> [AXUIElement] {
+        var rows: [AXUIElement] = []
         for row in children(table) {
             guard role(row) == "AXRow" else { continue }
             for cell in children(row) {
@@ -247,12 +253,13 @@ public enum AXHelpers {
                     guard likelyDisplayName else { continue }
                     let matches = exact ? name == chatName : name.localizedCaseInsensitiveContains(chatName)
                     if matches {
-                        return row
+                        rows.append(row)
+                        break
                     }
                 }
             }
         }
-        return nil
+        return rows
     }
 
     /// Find the self-chat row (identified by "badge me" image in the cell).

--- a/Sources/KakaoCore/Automation/AXHelpers.swift
+++ b/Sources/KakaoCore/Automation/AXHelpers.swift
@@ -186,6 +186,48 @@ public enum AXHelpers {
         return nil
     }
 
+    /// Find the message composer for a conversation window or inline chat view.
+    /// The composer usually lives inside a scroll area that does not contain the
+    /// message table, but some KakaoTalk builds expose it only via a deeper global search.
+    public static func findMessageComposer(in window: AXUIElement) -> AXUIElement? {
+        for child in children(window) {
+            guard role(child) == "AXScrollArea" else { continue }
+            let hasTable = children(child).contains { role($0) == "AXTable" }
+            if !hasTable {
+                if let composer = findComposer(in: child, maxDepth: 4) {
+                    return composer
+                }
+            }
+        }
+        return findComposer(in: window, maxDepth: 8)
+    }
+
+    private static func findComposer(in element: AXUIElement, maxDepth: Int) -> AXUIElement? {
+        let textAreas = findAll(element, role: "AXTextArea", maxDepth: maxDepth)
+        if let composer = textAreas.first(where: isLikelyMessageComposer) {
+            return composer
+        }
+        if let composer = textAreas.first {
+            return composer
+        }
+
+        let textFields = findAll(element, role: "AXTextField", maxDepth: maxDepth)
+        if let composer = textFields.first(where: isLikelyMessageComposer) {
+            return composer
+        }
+        if let composer = textFields.first {
+            return composer
+        }
+        return nil
+    }
+
+    private static func isLikelyMessageComposer(_ element: AXUIElement) -> Bool {
+        let desc = (description(element) ?? "").lowercased()
+        return desc.contains("enter a message") ||
+            desc.contains("message") ||
+            desc.contains("메시지")
+    }
+
     /// Find the AXRow in a chat list whose name label matches the given text.
     /// Older/newer KakaoTalk builds vary between AXTable and AXOutline and may
     /// expose the visible name as "_NS:18", "Display Name", or a plain static text.

--- a/Sources/KakaoCore/Automation/AppLifecycle.swift
+++ b/Sources/KakaoCore/Automation/AppLifecycle.swift
@@ -201,23 +201,10 @@ public enum AppLifecycle {
         case .notRunning:
             fputs("Launching KakaoTalk...\n", stderr)
             try launch()
-            let afterLaunch = waitForAnyState([.loggedIn, .loginScreen, .updateRequired], timeout: 15.0)
-            if afterLaunch == .loggedIn { return }
-            if afterLaunch == .updateRequired { throw LifecycleError.updateRequired }
-            if afterLaunch == .loginScreen {
-                try attemptLogin(credentials: credentials)
-                return
-            }
-            throw LifecycleError.launchTimeout
+            try waitForReadyAfterLaunch(credentials: credentials)
 
         case .launching:
-            let afterWait = waitForAnyState([.loggedIn, .loginScreen, .updateRequired], timeout: 15.0)
-            if afterWait == .loggedIn { return }
-            if afterWait == .loginScreen {
-                try attemptLogin(credentials: credentials)
-                return
-            }
-            throw LifecycleError.launchTimeout
+            try waitForReadyAfterLaunch(credentials: credentials)
 
         case .loginScreen:
             try attemptLogin(credentials: credentials)
@@ -231,6 +218,41 @@ public enum AppLifecycle {
     }
 
     // MARK: - Private
+
+    private static func waitForReadyAfterLaunch(
+        credentials: CredentialStore?,
+        timeout: TimeInterval = 15.0
+    ) throws {
+        let afterWait = waitForAnyState([.loggedIn, .loginScreen, .updateRequired], timeout: timeout)
+        switch afterWait {
+        case .loggedIn:
+            try ensureWindowVisible()
+            return
+        case .loginScreen:
+            try attemptLogin(credentials: credentials)
+            return
+        case .updateRequired:
+            throw LifecycleError.updateRequired
+        case .notRunning, .launching, .unknown:
+            break
+        }
+
+        // KakaoTalk can be logged in but expose no AXWindow right after launch.
+        // Re-run the state detector in aggressive mode so it may reveal the menu-bar-only window.
+        let afterReveal = detectState(aggressive: true)
+        switch afterReveal {
+        case .loggedIn:
+            try ensureWindowVisible()
+            return
+        case .loginScreen:
+            try attemptLogin(credentials: credentials)
+            return
+        case .updateRequired:
+            throw LifecycleError.updateRequired
+        case .notRunning, .launching, .unknown:
+            throw LifecycleError.launchTimeout
+        }
+    }
 
     /// Ensure KakaoTalk's main window is visible with the chat list accessible.
     /// KakaoTalk sometimes hides its window even when logged in.

--- a/Sources/KakaoCore/Automation/AutomationPermissions.swift
+++ b/Sources/KakaoCore/Automation/AutomationPermissions.swift
@@ -1,0 +1,129 @@
+import ApplicationServices
+import Foundation
+
+public enum AutomationPermissionStatus: Equatable {
+    case granted
+    case denied(String?)
+    case unknown(String?)
+
+    public var label: String {
+        switch self {
+        case .granted:
+            return "Granted"
+        case .denied:
+            return "Denied"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+
+    public var details: String? {
+        switch self {
+        case .granted:
+            return nil
+        case .denied(let details), .unknown(let details):
+            return details
+        }
+    }
+}
+
+public struct AutomationPermissionReport {
+    public let binaryPath: String
+    public let accessibilityTrusted: Bool
+    public let systemEventsAutomation: AutomationPermissionStatus
+}
+
+public enum AutomationPermissionError: Error, CustomStringConvertible {
+    case accessibilityDenied(binaryPath: String)
+    case systemEventsDenied(binaryPath: String, details: String?)
+    case systemEventsUnknown(binaryPath: String, details: String?)
+
+    public var description: String {
+        switch self {
+        case .accessibilityDenied(let binaryPath):
+            return "Accessibility permission is not granted for \(binaryPath)"
+        case .systemEventsDenied(let binaryPath, let details):
+            if let details, !details.isEmpty {
+                return "System Events automation is denied for \(binaryPath): \(details)"
+            }
+            return "System Events automation is denied for \(binaryPath)"
+        case .systemEventsUnknown(let binaryPath, let details):
+            if let details, !details.isEmpty {
+                return "Could not verify System Events automation for \(binaryPath): \(details)"
+            }
+            return "Could not verify System Events automation for \(binaryPath)"
+        }
+    }
+}
+
+public enum AutomationPermissions {
+    public static func currentBinaryPath() -> String {
+        URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath().path
+    }
+
+    public static func report() -> AutomationPermissionReport {
+        AutomationPermissionReport(
+            binaryPath: currentBinaryPath(),
+            accessibilityTrusted: AXIsProcessTrusted(),
+            systemEventsAutomation: probeSystemEventsAutomation()
+        )
+    }
+
+    public static func requireForSend() throws {
+        let current = report()
+        guard current.accessibilityTrusted else {
+            throw AutomationPermissionError.accessibilityDenied(binaryPath: current.binaryPath)
+        }
+        switch current.systemEventsAutomation {
+        case .granted:
+            return
+        case .denied(let details):
+            throw AutomationPermissionError.systemEventsDenied(
+                binaryPath: current.binaryPath,
+                details: details
+            )
+        case .unknown(let details):
+            throw AutomationPermissionError.systemEventsUnknown(
+                binaryPath: current.binaryPath,
+                details: details
+            )
+        }
+    }
+
+    private static func probeSystemEventsAutomation() -> AutomationPermissionStatus {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [
+            "-e",
+            "tell application \"System Events\" to return name of first application process",
+        ]
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return .unknown(error.localizedDescription)
+        }
+
+        let out = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let err = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let combined = "\(out)\n\(err)".trimmingCharacters(in: .whitespacesAndNewlines)
+        if process.terminationStatus == 0 {
+            return .granted
+        }
+
+        let normalized = combined.lowercased()
+        if normalized.contains("-1743") ||
+            normalized.contains("not authorized") ||
+            normalized.contains("not permitted") ||
+            normalized.contains("automation") {
+            return .denied(combined.isEmpty ? nil : combined)
+        }
+
+        return .unknown(combined.isEmpty ? "osascript exited with status \(process.terminationStatus)" : combined)
+    }
+}

--- a/Sources/KakaoCore/Automation/KakaoAutomator.swift
+++ b/Sources/KakaoCore/Automation/KakaoAutomator.swift
@@ -10,93 +10,19 @@ public final class KakaoAutomator {
 
     /// Send a message to a chat by navigating the UI.
     public func sendMessage(to chatName: String, message: String, selfChat: Bool = false) throws {
-        // 1. Ensure KakaoTalk is running and logged in
-        let stateBefore = AppLifecycle.detectState()
-        try AppLifecycle.ensureReady(credentials: CredentialStore())
-        if stateBefore != .loggedIn {
-            Thread.sleep(forTimeInterval: 2.0)
-        }
+        let session = try openConversation(to: chatName, selfChat: selfChat)
 
-        // 2. Activate KakaoTalk and get windows
-        try AXHelpers.activateApp(bundleId: Self.bundleId)
-        let app = try AXHelpers.appElement(bundleId: Self.bundleId)
-
-        let windows = AXHelpers.windows(app)
-        guard let mainWindow = windows.first(where: { AXHelpers.identifier($0) == "Main Window" }) else {
-            throw AutomationError.noWindows
-        }
-
-        // 3. Close any existing chat windows to avoid sending to the wrong one
-        for w in windows where AXHelpers.identifier(w) != "Main Window" {
-            _ = AXHelpers.closeWindow(w)
-        }
-        if windows.count > 1 {
-            Thread.sleep(forTimeInterval: 0.3)
-        }
-
-        // 4. Ensure we're on the Chats tab
-        let chatroomsTab =
-            AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") ??
-            AXHelpers.findFirst(mainWindow, role: "AXButton", identifier: "chatrooms")
-        if let chatroomsTab {
-            _ = AXHelpers.performAction(chatroomsTab, kAXPressAction as String)
-            Thread.sleep(forTimeInterval: 0.3)
-        }
-
-        // 5. Find the chat row in the list
-        guard let table = AXHelpers.chatListTable(mainWindow) else {
-            throw AutomationError.chatNotFound(chatName)
-        }
-
-        let row: AXUIElement
-        if selfChat {
-            guard let selfRow = AXHelpers.findSelfChatRow(table) else {
-                throw AutomationError.chatNotFound("self-chat (나와의 채팅)")
-            }
-            row = selfRow
-        } else {
-            guard let chatRow = AXHelpers.findChatRow(table, chatName: chatName) else {
-                throw AutomationError.chatNotFound(chatName)
-            }
-            row = chatRow
-        }
-
-        // 6. Open the chat via AX row selection + Enter (works even when off-screen).
-        //    Falls back to scroll-into-view + double-click if selection fails.
-        var opened = false
-        if AXHelpers.selectRow(row, in: table) {
-            Thread.sleep(forTimeInterval: 0.2)
-            AXHelpers.pressKey(keyCode: 36) // Enter to open
-            Thread.sleep(forTimeInterval: 0.5)
-            let checkWindows = AXHelpers.windows(app)
-            opened = checkWindows.contains { AXHelpers.identifier($0) != "Main Window" }
-        }
-        if !opened {
-            if let scrollArea = AXHelpers.chatListScrollArea(mainWindow) {
-                _ = AXHelpers.scrollRowToVisible(row, in: scrollArea)
-                Thread.sleep(forTimeInterval: 0.3)
-            }
-            AXHelpers.doubleClickElement(row)
-        }
-
-        // 7. Wait for the chat window to appear
-        var chatWindow: AXUIElement?
-        let windowDeadline = Date().addingTimeInterval(5.0)
-        while Date() < windowDeadline {
-            Thread.sleep(forTimeInterval: 0.5)
-            let updatedWindows = AXHelpers.windows(app)
-            chatWindow = updatedWindows.first(where: { AXHelpers.identifier($0) != "Main Window" })
-            if chatWindow != nil { break }
-        }
-        guard let chatWindow else {
-            throw AutomationError.inputFieldNotFound
-        }
-
-        // 8. Wait briefly for the message composer to become available.
-        let inputDeadline = Date().addingTimeInterval(5.0)
+        // Wait briefly for the message composer to become available.
+        let inputDeadline = Date().addingTimeInterval(10.0)
+        var activeContainer = session.conversationContainer
         var inputField: AXUIElement?
         while Date() < inputDeadline {
-            inputField = findInputField(in: chatWindow)
+            inputField = AXHelpers.findMessageComposer(in: activeContainer)
+            if inputField == nil, AXHelpers.identifier(activeContainer) != "Main Window",
+               let inlineInput = AXHelpers.findMessageComposer(in: session.mainWindow) {
+                activeContainer = session.mainWindow
+                inputField = inlineInput
+            }
             if inputField != nil { break }
             Thread.sleep(forTimeInterval: 0.25)
         }
@@ -104,8 +30,8 @@ public final class KakaoAutomator {
             throw AutomationError.inputFieldNotFound
         }
 
-        // 9. Focus and type the message
-        _ = AXHelpers.performAction(chatWindow, kAXRaiseAction as String)
+        // Focus and type the message.
+        _ = AXHelpers.performAction(activeContainer, kAXRaiseAction as String)
         Thread.sleep(forTimeInterval: 0.3)
         AXHelpers.clickElement(inputField)
         Thread.sleep(forTimeInterval: 0.3)
@@ -121,46 +47,245 @@ public final class KakaoAutomator {
             AXHelpers.pressKey(keyCode: 36) // Return key
         }
 
-        // 10. Close the chat window
         Thread.sleep(forTimeInterval: 0.3)
-        _ = AXHelpers.closeWindow(chatWindow)
+        if AXHelpers.identifier(activeContainer) != "Main Window" {
+            _ = AXHelpers.closeWindow(activeContainer)
+        }
     }
 
-    /// Find the message composer in a chat window.
-    /// The composer lives inside a top-level AXScrollArea that does not contain the
-    /// message AXTable. Some KakaoTalk builds wrap the editable field deeper than one level.
-    private func findInputField(in window: AXUIElement) -> AXUIElement? {
-        for child in AXHelpers.children(window) {
-            guard AXHelpers.role(child) == "AXScrollArea" else { continue }
-            // The message list scroll area contains an AXTable; the composer one doesn't.
-            let hasTable = AXHelpers.children(child).contains { AXHelpers.role($0) == "AXTable" }
-            if !hasTable {
-                let textAreas = AXHelpers.findAll(child, role: "AXTextArea", maxDepth: 4)
-                if let composer = textAreas.first(where: {
-                    let desc = AXHelpers.description($0) ?? ""
-                    return desc.localizedCaseInsensitiveContains("enter a message")
-                }) {
-                    return composer
-                }
-                if let composer = textAreas.first {
-                    return composer
-                }
+    /// Leave a group chat through KakaoTalk's chat window menu.
+    public func leaveChat(to chatName: String) throws {
+        let session = try openConversation(to: chatName, selfChat: false, exactChatName: true)
+        _ = AXHelpers.performAction(session.conversationContainer, kAXRaiseAction as String)
+        Thread.sleep(forTimeInterval: 0.3)
 
-                let textFields = AXHelpers.findAll(child, role: "AXTextField", maxDepth: 4)
-                if let composer = textFields.first(where: {
-                    let desc = AXHelpers.description($0) ?? ""
-                    return desc.localizedCaseInsensitiveContains("enter a message")
-                }) {
-                    return composer
+        guard let menuButton = findConversationMenuButton(in: session.conversationContainer) else {
+            throw AutomationError.menuButtonNotFound(chatName)
+        }
+
+        if !AXHelpers.performAction(menuButton, kAXPressAction as String) {
+            AXHelpers.clickElement(menuButton)
+        }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        guard let leaveItem = waitForMenuItem(
+            in: session.app,
+            labels: ["Leave chatroom", "Leave Chatroom", "Leave Chat", "채팅방 나가기", "나가기"],
+            timeout: 3.0
+        ) else {
+            throw AutomationError.leaveMenuItemNotFound(chatName)
+        }
+        if !AXHelpers.performAction(leaveItem, kAXPressAction as String) {
+            AXHelpers.clickElement(leaveItem)
+        }
+
+        if let confirmButton = waitForConfirmationButton(
+            in: session.app,
+            includeLabels: ["Leave", "Leave chatroom", "Leave Chatroom", "Leave Chat Room", "OK", "확인", "나가기"],
+            excludeLabels: ["Cancel", "취소", "No", "아니오"],
+            timeout: 5.0
+        ) {
+            if !AXHelpers.performAction(confirmButton, kAXPressAction as String) {
+                AXHelpers.clickElement(confirmButton)
+            }
+        } else if hasConfirmationPrompt(in: session.app) {
+            throw AutomationError.leaveConfirmationButtonNotFound(chatName)
+        }
+    }
+
+    private struct ConversationSession {
+        let app: AXUIElement
+        let mainWindow: AXUIElement
+        let conversationContainer: AXUIElement
+    }
+
+    private func openConversation(
+        to chatName: String,
+        selfChat: Bool,
+        exactChatName: Bool = false
+    ) throws -> ConversationSession {
+        let stateBefore = AppLifecycle.detectState()
+        try AppLifecycle.ensureReady(credentials: CredentialStore())
+        if stateBefore != .loggedIn {
+            Thread.sleep(forTimeInterval: 2.0)
+        }
+
+        try AXHelpers.activateApp(bundleId: Self.bundleId)
+        let app = try AXHelpers.appElement(bundleId: Self.bundleId)
+
+        let windows = AXHelpers.windows(app)
+        guard let mainWindow = windows.first(where: { AXHelpers.identifier($0) == "Main Window" }) else {
+            throw AutomationError.noWindows
+        }
+
+        // Close existing chat windows so the next action cannot target an old conversation.
+        for window in windows where AXHelpers.identifier(window) != "Main Window" {
+            _ = AXHelpers.closeWindow(window)
+        }
+        if windows.count > 1 {
+            Thread.sleep(forTimeInterval: 0.3)
+        }
+
+        let chatroomsTab =
+            AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") ??
+            AXHelpers.findFirst(mainWindow, role: "AXButton", identifier: "chatrooms")
+        if let chatroomsTab {
+            _ = AXHelpers.performAction(chatroomsTab, kAXPressAction as String)
+            Thread.sleep(forTimeInterval: 0.3)
+        }
+
+        guard let table = AXHelpers.chatListTable(mainWindow) else {
+            throw AutomationError.chatNotFound(chatName)
+        }
+
+        let row: AXUIElement
+        if selfChat {
+            guard let selfRow = AXHelpers.findSelfChatRow(table) else {
+                throw AutomationError.chatNotFound("self-chat (나와의 채팅)")
+            }
+            row = selfRow
+        } else {
+            guard let chatRow = AXHelpers.findChatRow(table, chatName: chatName, exact: exactChatName) else {
+                throw AutomationError.chatNotFound(chatName)
+            }
+            row = chatRow
+        }
+
+        func waitForConversationContainer(timeout: TimeInterval = 2.0) -> AXUIElement? {
+            let deadline = Date().addingTimeInterval(timeout)
+            while Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.25)
+                let updatedWindows = AXHelpers.windows(app)
+                if let chatWindow = updatedWindows.first(where: { AXHelpers.identifier($0) != "Main Window" }) {
+                    return chatWindow
                 }
-                if let composer = textFields.first {
-                    return composer
+                if AXHelpers.findMessageComposer(in: mainWindow) != nil {
+                    return mainWindow
                 }
             }
+            return nil
+        }
+
+        var conversationContainer: AXUIElement?
+        if AXHelpers.selectRow(row, in: table) {
+            Thread.sleep(forTimeInterval: 0.2)
+            AXHelpers.pressKey(keyCode: 36) // Enter to open
+            conversationContainer = waitForConversationContainer()
+        }
+        if conversationContainer == nil {
+            AXHelpers.clickElement(row)
+            Thread.sleep(forTimeInterval: 0.2)
+            AXHelpers.pressKey(keyCode: 36)
+            conversationContainer = waitForConversationContainer()
+        }
+        if conversationContainer == nil,
+           let nameLabel = AXHelpers.findFirst(row, role: "AXStaticText", text: chatName, maxDepth: 4) {
+            AXHelpers.doubleClickElement(nameLabel)
+            conversationContainer = waitForConversationContainer()
+        }
+        if conversationContainer == nil,
+           let cell = AXHelpers.children(row).first(where: { AXHelpers.role($0) == "AXCell" }) {
+            AXHelpers.doubleClickElement(cell)
+            conversationContainer = waitForConversationContainer()
+        }
+        if conversationContainer == nil {
+            if let scrollArea = AXHelpers.chatListScrollArea(mainWindow) {
+                _ = AXHelpers.scrollRowToVisible(row, in: scrollArea)
+                Thread.sleep(forTimeInterval: 0.3)
+            }
+            AXHelpers.doubleClickElement(row)
+            conversationContainer = waitForConversationContainer(timeout: 5.0)
+        }
+
+        guard let conversationContainer else {
+            throw AutomationError.inputFieldNotFound
+        }
+        return ConversationSession(
+            app: app,
+            mainWindow: mainWindow,
+            conversationContainer: conversationContainer
+        )
+    }
+
+    private func findConversationMenuButton(in container: AXUIElement) -> AXUIElement? {
+        AXHelpers.findAll(container, role: "AXButton", maxDepth: 12).first { element in
+            labelMatches(element, include: ["Menu", "메뉴"])
+        }
+    }
+
+    private func waitForMenuItem(
+        in app: AXUIElement,
+        labels: [String],
+        timeout: TimeInterval
+    ) -> AXUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            for root in searchRoots(for: app) {
+                if let item = AXHelpers.findAll(root, role: "AXMenuItem", maxDepth: 14).first(where: {
+                    labelMatches($0, include: labels)
+                }) {
+                    return item
+                }
+            }
+            Thread.sleep(forTimeInterval: 0.2)
         }
         return nil
     }
 
+    private func waitForConfirmationButton(
+        in app: AXUIElement,
+        includeLabels: [String],
+        excludeLabels: [String],
+        timeout: TimeInterval
+    ) -> AXUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            for root in searchRoots(for: app) {
+                if let button = AXHelpers.findAll(root, role: "AXButton", maxDepth: 14).first(where: {
+                    labelMatches($0, include: includeLabels, exclude: excludeLabels)
+                }) {
+                    return button
+                }
+            }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        return nil
+    }
+
+    private func hasConfirmationPrompt(in app: AXUIElement) -> Bool {
+        searchRoots(for: app).contains { root in
+            AXHelpers.findAll(root, role: "AXButton", maxDepth: 14).contains {
+                labelMatches($0, include: ["Cancel", "취소", "No", "아니오"])
+            }
+        }
+    }
+
+    private func searchRoots(for app: AXUIElement) -> [AXUIElement] {
+        [app] + AXHelpers.windows(app)
+    }
+
+    private func labelMatches(
+        _ element: AXUIElement,
+        include: [String],
+        exclude: [String] = []
+    ) -> Bool {
+        let labels = [
+            AXHelpers.title(element),
+            AXHelpers.value(element),
+            AXHelpers.description(element),
+        ]
+        .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+        guard labels.contains(where: { label in
+            include.contains(where: { label.localizedCaseInsensitiveContains($0) })
+        }) else {
+            return false
+        }
+        return !labels.contains(where: { label in
+            exclude.contains(where: { label.localizedCaseInsensitiveContains($0) })
+        })
+    }
 }
 
 public enum AutomationError: Error, CustomStringConvertible {
@@ -168,6 +293,9 @@ public enum AutomationError: Error, CustomStringConvertible {
     case chatNotFound(String)
     case inputFieldNotFound
     case sendFailed(String)
+    case menuButtonNotFound(String)
+    case leaveMenuItemNotFound(String)
+    case leaveConfirmationButtonNotFound(String)
 
     public var description: String {
         switch self {
@@ -179,6 +307,12 @@ public enum AutomationError: Error, CustomStringConvertible {
             return "Could not find the message input field"
         case .sendFailed(let msg):
             return "Failed to send message: \(msg)"
+        case .menuButtonNotFound(let name):
+            return "Could not find the chat menu button for '\(name)'"
+        case .leaveMenuItemNotFound(let name):
+            return "Could not find the leave-chatroom menu item for '\(name)'"
+        case .leaveConfirmationButtonNotFound(let name):
+            return "Could not find the leave confirmation button for '\(name)'"
         }
     }
 }

--- a/Sources/KakaoCore/Automation/KakaoAutomator.swift
+++ b/Sources/KakaoCore/Automation/KakaoAutomator.swift
@@ -11,7 +11,16 @@ public final class KakaoAutomator {
     /// Send a message to a chat by navigating the UI.
     public func sendMessage(to chatName: String, message: String, selfChat: Bool = false) throws {
         let session = try openConversation(to: chatName, selfChat: selfChat)
+        try sendMessage(message: message, in: session)
+    }
 
+    /// Send a message to the chat row at a known database/UI index.
+    public func sendMessage(toChatAtIndex index: Int, targetDescription: String, message: String) throws {
+        let session = try openConversation(toChatAtIndex: index, targetDescription: targetDescription)
+        try sendMessage(message: message, in: session)
+    }
+
+    private func sendMessage(message: String, in session: ConversationSession) throws {
         // Wait briefly for the message composer to become available.
         let inputDeadline = Date().addingTimeInterval(10.0)
         var activeContainer = session.conversationContainer
@@ -99,11 +108,42 @@ public final class KakaoAutomator {
         let conversationContainer: AXUIElement
     }
 
+    private enum ChatTarget {
+        case name(String, exact: Bool)
+        case rowIndex(Int, description: String)
+        case selfChat
+
+        var description: String {
+            switch self {
+            case .name(let name, _):
+                return name
+            case .rowIndex(_, let description):
+                return description
+            case .selfChat:
+                return "self-chat (나와의 채팅)"
+            }
+        }
+    }
+
     private func openConversation(
         to chatName: String,
         selfChat: Bool,
         exactChatName: Bool = false
     ) throws -> ConversationSession {
+        if selfChat {
+            return try openConversation(target: .selfChat)
+        }
+        return try openConversation(target: .name(chatName, exact: exactChatName))
+    }
+
+    private func openConversation(
+        toChatAtIndex index: Int,
+        targetDescription: String
+    ) throws -> ConversationSession {
+        try openConversation(target: .rowIndex(index, description: targetDescription))
+    }
+
+    private func openConversation(target: ChatTarget) throws -> ConversationSession {
         let stateBefore = AppLifecycle.detectState()
         try AppLifecycle.ensureReady(credentials: CredentialStore())
         if stateBefore != .loggedIn {
@@ -135,16 +175,17 @@ public final class KakaoAutomator {
         }
 
         guard let table = AXHelpers.chatListTable(mainWindow) else {
-            throw AutomationError.chatNotFound(chatName)
+            throw AutomationError.chatNotFound(target.description)
         }
 
         let row: AXUIElement
-        if selfChat {
+        switch target {
+        case .selfChat:
             guard let selfRow = AXHelpers.findSelfChatRow(table) else {
                 throw AutomationError.chatNotFound("self-chat (나와의 채팅)")
             }
             row = selfRow
-        } else {
+        case .name(let chatName, let exactChatName):
             let chatRows = AXHelpers.findChatRows(table, chatName: chatName, exact: exactChatName)
             guard !chatRows.isEmpty, let chatRow = chatRows.first else {
                 throw AutomationError.chatNotFound(chatName)
@@ -153,6 +194,12 @@ public final class KakaoAutomator {
                 throw AutomationError.ambiguousChatName(chatName, chatRows.count)
             }
             row = chatRow
+        case .rowIndex(let index, let description):
+            let rows = AXHelpers.children(table).filter { AXHelpers.role($0) == "AXRow" }
+            guard index >= 0 && index < rows.count else {
+                throw AutomationError.chatNotFound(description)
+            }
+            row = rows[index]
         }
 
         func waitForConversationContainer(timeout: TimeInterval = 2.0) -> AXUIElement? {
@@ -183,6 +230,7 @@ public final class KakaoAutomator {
             conversationContainer = waitForConversationContainer()
         }
         if conversationContainer == nil,
+           case .name(let chatName, _) = target,
            let nameLabel = AXHelpers.findFirst(row, role: "AXStaticText", text: chatName, maxDepth: 4) {
             AXHelpers.doubleClickElement(nameLabel)
             conversationContainer = waitForConversationContainer()

--- a/Sources/KakaoCore/Automation/KakaoAutomator.swift
+++ b/Sources/KakaoCore/Automation/KakaoAutomator.swift
@@ -35,7 +35,10 @@ public final class KakaoAutomator {
         }
 
         // 4. Ensure we're on the Chats tab
-        if let chatroomsTab = AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") {
+        let chatroomsTab =
+            AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") ??
+            AXHelpers.findFirst(mainWindow, role: "AXButton", identifier: "chatrooms")
+        if let chatroomsTab {
             _ = AXHelpers.performAction(chatroomsTab, kAXPressAction as String)
             Thread.sleep(forTimeInterval: 0.3)
         }
@@ -89,8 +92,15 @@ public final class KakaoAutomator {
             throw AutomationError.inputFieldNotFound
         }
 
-        // 8. Find the message input field
-        guard let inputField = findInputField(in: chatWindow) else {
+        // 8. Wait briefly for the message composer to become available.
+        let inputDeadline = Date().addingTimeInterval(5.0)
+        var inputField: AXUIElement?
+        while Date() < inputDeadline {
+            inputField = findInputField(in: chatWindow)
+            if inputField != nil { break }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        guard let inputField else {
             throw AutomationError.inputFieldNotFound
         }
 
@@ -116,19 +126,35 @@ public final class KakaoAutomator {
         _ = AXHelpers.closeWindow(chatWindow)
     }
 
-    /// Find the message input AXTextArea in a chat window.
-    /// The input is in a top-level AXScrollArea that does NOT contain an AXTable (messages).
+    /// Find the message composer in a chat window.
+    /// The composer lives inside a top-level AXScrollArea that does not contain the
+    /// message AXTable. Some KakaoTalk builds wrap the editable field deeper than one level.
     private func findInputField(in window: AXUIElement) -> AXUIElement? {
         for child in AXHelpers.children(window) {
             guard AXHelpers.role(child) == "AXScrollArea" else { continue }
-            // The message list scroll area contains an AXTable; the input one doesn't
+            // The message list scroll area contains an AXTable; the composer one doesn't.
             let hasTable = AXHelpers.children(child).contains { AXHelpers.role($0) == "AXTable" }
             if !hasTable {
-                // This scroll area should contain the input AXTextArea
-                for subchild in AXHelpers.children(child) {
-                    if AXHelpers.role(subchild) == "AXTextArea" {
-                        return subchild
-                    }
+                let textAreas = AXHelpers.findAll(child, role: "AXTextArea", maxDepth: 4)
+                if let composer = textAreas.first(where: {
+                    let desc = AXHelpers.description($0) ?? ""
+                    return desc.localizedCaseInsensitiveContains("enter a message")
+                }) {
+                    return composer
+                }
+                if let composer = textAreas.first {
+                    return composer
+                }
+
+                let textFields = AXHelpers.findAll(child, role: "AXTextField", maxDepth: 4)
+                if let composer = textFields.first(where: {
+                    let desc = AXHelpers.description($0) ?? ""
+                    return desc.localizedCaseInsensitiveContains("enter a message")
+                }) {
+                    return composer
+                }
+                if let composer = textFields.first {
+                    return composer
                 }
             }
         }

--- a/Sources/KakaoCore/Automation/KakaoAutomator.swift
+++ b/Sources/KakaoCore/Automation/KakaoAutomator.swift
@@ -9,8 +9,13 @@ public final class KakaoAutomator {
     public init() {}
 
     /// Send a message to a chat by navigating the UI.
-    public func sendMessage(to chatName: String, message: String, selfChat: Bool = false) throws {
-        let session = try openConversation(to: chatName, selfChat: selfChat)
+    public func sendMessage(
+        to chatName: String,
+        message: String,
+        selfChat: Bool = false,
+        exactChatName: Bool = false
+    ) throws {
+        let session = try openConversation(to: chatName, selfChat: selfChat, exactChatName: exactChatName)
         try sendMessage(message: message, in: session)
     }
 
@@ -65,11 +70,21 @@ public final class KakaoAutomator {
     /// Leave a group chat through KakaoTalk's chat window menu.
     public func leaveChat(to chatName: String) throws {
         let session = try openConversation(to: chatName, selfChat: false, exactChatName: true)
+        try leaveChat(in: session, targetDescription: chatName)
+    }
+
+    /// Leave a group chat using a known chat row index.
+    public func leaveChat(atChatIndex index: Int, targetDescription: String) throws {
+        let session = try openConversation(toChatAtIndex: index, targetDescription: targetDescription)
+        try leaveChat(in: session, targetDescription: targetDescription)
+    }
+
+    private func leaveChat(in session: ConversationSession, targetDescription: String) throws {
         _ = AXHelpers.performAction(session.conversationContainer, kAXRaiseAction as String)
         Thread.sleep(forTimeInterval: 0.3)
 
         guard let menuButton = findConversationMenuButton(in: session.conversationContainer) else {
-            throw AutomationError.menuButtonNotFound(chatName)
+            throw AutomationError.menuButtonNotFound(targetDescription)
         }
 
         if !AXHelpers.performAction(menuButton, kAXPressAction as String) {
@@ -82,7 +97,7 @@ public final class KakaoAutomator {
             labels: ["Leave chatroom", "Leave Chatroom", "Leave Chat", "채팅방 나가기", "나가기"],
             timeout: 3.0
         ) else {
-            throw AutomationError.leaveMenuItemNotFound(chatName)
+            throw AutomationError.leaveMenuItemNotFound(targetDescription)
         }
         if !AXHelpers.performAction(leaveItem, kAXPressAction as String) {
             AXHelpers.clickElement(leaveItem)
@@ -98,7 +113,7 @@ public final class KakaoAutomator {
                 AXHelpers.clickElement(confirmButton)
             }
         } else if hasConfirmationPrompt(in: session.app) {
-            throw AutomationError.leaveConfirmationButtonNotFound(chatName)
+            throw AutomationError.leaveConfirmationButtonNotFound(targetDescription)
         }
     }
 

--- a/Sources/KakaoCore/Automation/KakaoAutomator.swift
+++ b/Sources/KakaoCore/Automation/KakaoAutomator.swift
@@ -145,8 +145,12 @@ public final class KakaoAutomator {
             }
             row = selfRow
         } else {
-            guard let chatRow = AXHelpers.findChatRow(table, chatName: chatName, exact: exactChatName) else {
+            let chatRows = AXHelpers.findChatRows(table, chatName: chatName, exact: exactChatName)
+            guard !chatRows.isEmpty, let chatRow = chatRows.first else {
                 throw AutomationError.chatNotFound(chatName)
+            }
+            if exactChatName && chatRows.count > 1 {
+                throw AutomationError.ambiguousChatName(chatName, chatRows.count)
             }
             row = chatRow
         }
@@ -293,6 +297,7 @@ public enum AutomationError: Error, CustomStringConvertible {
     case chatNotFound(String)
     case inputFieldNotFound
     case sendFailed(String)
+    case ambiguousChatName(String, Int)
     case menuButtonNotFound(String)
     case leaveMenuItemNotFound(String)
     case leaveConfirmationButtonNotFound(String)
@@ -307,6 +312,8 @@ public enum AutomationError: Error, CustomStringConvertible {
             return "Could not find the message input field"
         case .sendFailed(let msg):
             return "Failed to send message: \(msg)"
+        case .ambiguousChatName(let name, let count):
+            return "Chat '\(name)' matched \(count) rows; refusing to continue"
         case .menuButtonNotFound(let name):
             return "Could not find the chat menu button for '\(name)'"
         case .leaveMenuItemNotFound(let name):

--- a/Sources/KakaoCore/Database/DatabaseReader.swift
+++ b/Sources/KakaoCore/Database/DatabaseReader.swift
@@ -214,7 +214,7 @@ public final class DatabaseReader: @unchecked Sendable {
         if !mentionTags.isEmpty {
             var mentionClauses: [String] = []
             for tag in mentionTags {
-                appendMentionPrefixPredicates(tag: tag, clauses: &mentionClauses, bindings: &bindings)
+                appendMentionPredicates(tag: tag, clauses: &mentionClauses, bindings: &bindings)
             }
             conditions.append(
                 "(r.type = 0 OR r.directChatMemberUserId IS NOT NULL OR (\(mentionClauses.joined(separator: " OR "))))"
@@ -252,18 +252,17 @@ public final class DatabaseReader: @unchecked Sendable {
         }
     }
 
-    private func appendMentionPrefixPredicates(
+    private func appendMentionPredicates(
         tag: String,
         clauses: inout [String],
         bindings: inout [SQLValue]
     ) {
-        let escapedTag = escapeLikePattern(tag)
-        clauses.append("m.message = ?")
-        bindings.append(.string(tag))
-        for separator in [" ", "\t", "\n", "\r", ",", ":", "-"] {
-            clauses.append("m.message LIKE ? ESCAPE '\\'")
-            bindings.append(.string("\(escapedTag)\(separator)%"))
-        }
+        clauses.append("m.message LIKE ? ESCAPE '\\'")
+        bindings.append(.string(buildMentionContainsLikePattern(tag)))
+    }
+
+    func buildMentionContainsLikePattern(_ raw: String) -> String {
+        "%\(escapeLikePattern(raw))%"
     }
 
     private func escapeLikePattern(_ raw: String) -> String {

--- a/Sources/KakaoCore/Database/DatabaseReader.swift
+++ b/Sources/KakaoCore/Database/DatabaseReader.swift
@@ -201,7 +201,26 @@ public final class DatabaseReader: @unchecked Sendable {
 
     /// Get messages with logId strictly greater than the given value.
     /// Returns SyncMessage structs suitable for JSON streaming.
-    public func messagesSince(logId: Int64, myUserId: Int64) throws -> [SyncMessage] {
+    public func messagesSince(
+        logId: Int64,
+        myUserId: Int64,
+        groupMentionTags: [String] = []
+    ) throws -> [SyncMessage] {
+        let mentionTags = groupMentionTags
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        var conditions = ["m.logId > ?"]
+        var bindings: [SQLValue] = [.int64(logId)]
+        if !mentionTags.isEmpty {
+            var mentionClauses: [String] = []
+            for tag in mentionTags {
+                appendMentionPrefixPredicates(tag: tag, clauses: &mentionClauses, bindings: &bindings)
+            }
+            conditions.append(
+                "(r.type = 0 OR r.directChatMemberUserId IS NOT NULL OR (\(mentionClauses.joined(separator: " OR "))))"
+            )
+        }
+        let whereClause = conditions.joined(separator: " AND ")
         let sql = """
             SELECT m.logId, m.chatId,
                    COALESCE(r.chatName, u.displayName, u.friendNickName, u.nickName) as chatName,
@@ -212,12 +231,12 @@ public final class DatabaseReader: @unchecked Sendable {
             LEFT JOIN NTChatRoom r ON m.chatId = r.chatId
             LEFT JOIN NTUser u ON r.directChatMemberUserId = u.userId AND u.linkId = 0
             LEFT JOIN NTUser u2 ON m.authorId = u2.userId AND u2.linkId = 0
-            WHERE m.logId > ?
+            WHERE \(whereClause)
             ORDER BY m.logId ASC
             LIMIT 100
             """
         let formatter = ISO8601DateFormatter()
-        return try query(sql, bind: [.int64(logId)]) { row in
+        return try query(sql, bind: bindings) { row in
             SyncMessage(
                 type: "message",
                 logId: row.int64(0),
@@ -231,6 +250,27 @@ public final class DatabaseReader: @unchecked Sendable {
                 isFromMe: row.int64(3) == myUserId
             )
         }
+    }
+
+    private func appendMentionPrefixPredicates(
+        tag: String,
+        clauses: inout [String],
+        bindings: inout [SQLValue]
+    ) {
+        let escapedTag = escapeLikePattern(tag)
+        clauses.append("m.message = ?")
+        bindings.append(.string(tag))
+        for separator in [" ", "\t", "\n", "\r", ",", ":", "-"] {
+            clauses.append("m.message LIKE ? ESCAPE '\\'")
+            bindings.append(.string("\(escapedTag)\(separator)%"))
+        }
+    }
+
+    private func escapeLikePattern(_ raw: String) -> String {
+        raw
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
     }
 
     /// Run an arbitrary read-only SQL query and return results as arrays of Any.

--- a/Sources/KakaoCore/Sync/DatabaseWatcher.swift
+++ b/Sources/KakaoCore/Sync/DatabaseWatcher.swift
@@ -9,13 +9,23 @@ public final class DatabaseWatcher: @unchecked Sendable {
     private let databasePath: String
     private let key: String?
     private let pollInterval: TimeInterval
+    private let groupMentionTags: [String]
     private var lastLogId: Int64
     private var running = false
 
-    public init(databasePath: String, key: String?, pollInterval: TimeInterval = 2.0, startFromLogId: Int64? = nil) {
+    public init(
+        databasePath: String,
+        key: String?,
+        pollInterval: TimeInterval = 2.0,
+        startFromLogId: Int64? = nil,
+        groupMentionTags: [String] = []
+    ) {
         self.databasePath = databasePath
         self.key = key
         self.pollInterval = pollInterval
+        self.groupMentionTags = groupMentionTags
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
         self.lastLogId = startFromLogId ?? 0
     }
 
@@ -68,7 +78,11 @@ public final class DatabaseWatcher: @unchecked Sendable {
         try reader.open(key: key)
         defer { reader.close() }
         let myUserId = try reader.myUserId()
-        return try reader.messagesSince(logId: lastLogId, myUserId: myUserId)
+        return try reader.messagesSince(
+            logId: lastLogId,
+            myUserId: myUserId,
+            groupMentionTags: groupMentionTags
+        )
     }
 }
 

--- a/Tests/KakaoCoreTests/GroupMentionFilteringTests.swift
+++ b/Tests/KakaoCoreTests/GroupMentionFilteringTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import KakaoCore
+
+@Test func testBuildMentionContainsLikePatternWrapsAndEscapesWildcards() {
+    let reader = DatabaseReader(databasePath: "/tmp/unused")
+    let pattern = reader.buildMentionContainsLikePattern("@clo_%")
+    #expect(pattern == #"%@clo\_\%%"#)
+}


### PR DESCRIPTION
## Summary
- support newer KakaoTalk Mac layouts where the Chats tab is exposed as `AXButton` instead of `AXCheckBox`
- support chat lists exposed as `AXOutline` and looser display-name labels instead of only `AXTable` + `_NS:18`
- wait briefly for the composer to appear and search recursively inside the non-message scroll area before failing send

## Details

### Root cause
On this machine, `kakaocli send` could still open the target chat, but failed at the final automation step with:

```text
Could not find the message input field
```

The current automation assumes a narrower Accessibility tree than the one exposed by the current KakaoTalk Mac app:

- the Chats tab may appear as `AXButton`
- the chat list may be exposed as `AXOutline`
- the composer may appear slightly later and can be nested deeper than one level inside the non-message `AXScrollArea`

### What changed
- accept either `AXCheckBox` or `AXButton` for the `chatrooms` tab in both send and inspect flows
- treat both `AXTable` and `AXOutline` as valid chat list containers
- relax chat row name matching so newer display-name labels are still discoverable
- wait up to 5 seconds for the composer after the chat window opens
- recursively search `AXTextArea` / `AXTextField` within the top-level non-table scroll area, preferring controls whose description contains `Enter a message`

### Debug evidence
Using `kakaocli inspect --open-chat <chat> --depth 5`, the chat window on the affected machine exposes the composer as:

```text
[AXWindow] title="성준"
  ...
  [AXScrollArea] id="_NS:47"
    [AXTextArea] desc="Enter a message" id="_NS:51"
```

The old code only checked direct children of the candidate scroll area once, immediately after the window appeared.

## Test plan
- [x] `swift build -c release` succeeds
- [x] `swift test` passes
- [x] `./.build/release/kakaocli inspect --open-chat 성준 --depth 5` shows the composer AX tree on the affected machine
- [x] `./.build/release/kakaocli send 성준 "[codex-pr-test] upstream clone patched send"` succeeds on the affected machine
