### PR TITLE
Raise SHA-512 userId recovery timeout from 10s to 120s

### DIFF
--- a/Sources/KakaoCore/Database/DeviceInfo.swift
+++ b/Sources/KakaoCore/Database/DeviceInfo.swift
@@ -194,7 +194,12 @@ public enum DeviceInfo {
     /// Recover a userId by brute-forcing the SHA-512 pre-image.
     /// KakaoTalk stores SHA-512(userId) as hex in plist keys. Since userIds are
     /// typically small integers, this is fast (< 1 second for IDs under 1M).
-    /// Searches up to 1 billion with a 10-second timeout.
+    /// Searches up to 1 billion with a 120-second timeout.
+    ///
+    /// Timeout was raised from 10s after an observed account with userId
+    /// ~25.7M where the Swift/CommonCrypto loop reached the checkpoint just
+    /// past the 10s budget and returned nil, causing key derivation to fall
+    /// back to AlertKakaoIDsList candidates (unrelated IDs) and failing auth.
     public static func recoverUserIdFromSHA512(hexHash: String) -> Int? {
         guard hexHash.count == 128 else { return nil }
         // Parse target hash to bytes
@@ -216,9 +221,9 @@ public enum DeviceInfo {
             if hash == targetBytes {
                 return i
             }
-            // Timeout after 10 seconds
+            // Timeout after 120 seconds
             if i % 5_000_000 == 0 && i > 0 {
-                if CFAbsoluteTimeGetCurrent() - startTime > 10 { return nil }
+                if CFAbsoluteTimeGetCurrent() - startTime > 120 { return nil }
             }
         }
         return nil


### PR DESCRIPTION
## Summary

`DeviceInfo.recoverUserIdFromSHA512` brute-forces the SHA-512 pre-image of the user ID encoded into plist revision keys (Strategy 3 in `userId()`). The loop currently caps at 10 seconds, which is too tight on real accounts in the ~25M+ userId range.

## Observed failure

On an account with `userId = 25790233`:

- `kakaocli auth` reports `User ID: NOT FOUND (candidates: 25411718, 344940307, 388584983, 366369712)`.
- Candidates come from `AlertKakaoIDsList` (muted/alerted accounts) — all unrelated to the active account.
- The account hash was detected correctly (`activeAccountHash()` returned `392b5035…ad69`), so Strategy 3 ran — it just timed out before reaching i = 25,790,233.
- Verified out-of-band with a parallel Python brute force: `SHA-512("25790233") = 392b5035…ad69` — elapsed ~7.9s on 8 cores. The single-thread Swift/CommonCrypto loop crosses the 10s checkpoint between i=25M and i=30M.
- `auth --user-id 25790233` succeeds immediately (DB opens, 19 tables found).

## Fix

Raise the timeout from 10s to 120s. The brute-force range (0..1B) is unchanged; 120s keeps the worst case bounded while covering realistic userId ranges on modern hardware.

## Alternatives considered

- Make the timeout configurable (env var or CLI flag) — larger surface area, deferred.
- Persist recovered userId to disk — reasonable follow-up but orthogonal to this fix.
- Use a faster hash impl (e.g. OpenSSL EVP, dispatched across cores) — much larger change; the 120s constant is sufficient for the reported range.

## Test plan

- [x] `swift build -c release` clean build on Swift 6.3.1 (swift.org toolchain) / macOS 15 arm64
- [x] `kakaocli auth` on the affected account: auto-detects userId without `--user-id` override
- [x] `kakaocli chats`, `kakaocli query` work against the decrypted DB post-auth