### PR TITLE
Resolve chat display names for open chats, group chats, and self-chat

### DIFF
--- a/Sources/KakaoCore/Database/DatabaseReader.swift
+++ b/Sources/KakaoCore/Database/DatabaseReader.swift
@@ -88,26 +88,94 @@ public final class DatabaseReader: @unchecked Sendable {
         let sql = """
             SELECT r.chatId, r.type, r.chatName, r.activeMembersCount,
                    r.lastLogId, r.lastUpdatedAt, r.countOfNewMessage,
-                   u.displayName, u.friendNickName, u.nickName
+                   u.displayName, u.friendNickName, u.nickName,
+                   ol.linkName, r.displayMemberIds
             FROM NTChatRoom r
             LEFT JOIN NTUser u ON r.directChatMemberUserId = u.userId AND u.linkId = 0
+            LEFT JOIN NTOpenLink ol ON r.linkId = ol.linkId AND r.linkId != 0
             ORDER BY r.lastUpdatedAt DESC
             LIMIT ?
             """
-        return try query(sql, bind: [.int(limit)]) { row in
-            // For direct chats, use the friend's name; for groups, use chatName
-            let chatName = row.string(2)
-            let displayName = row.string(7) ?? row.string(8) ?? row.string(9)
-            let name = chatName ?? displayName ?? "(unknown)"
 
-            return Chat(
+        // First pass: collect raw fields and any pending member-id lookups.
+        struct Raw {
+            let id: Int64; let type: Int; let chatName: String?; let direct: String?; let link: String?
+            let memberIds: [Int64]; let memberCount: Int; let lastMsgId: Int64?; let lastMsgAt: Date?; let unread: Int
+        }
+        func nonEmpty(_ s: String?) -> String? { (s?.isEmpty ?? true) ? nil : s }
+
+        let raws: [Raw] = try query(sql, bind: [.int(limit)]) { row in
+            let memberBlob = row.blob(11)
+            var members: [Int64] = []
+            if let data = memberBlob,
+               let obj = try? PropertyListSerialization.propertyList(from: data, format: nil),
+               let arr = obj as? [Any] {
+                members = arr.compactMap { v in
+                    if let i = v as? Int64 { return i }
+                    if let i = v as? Int { return Int64(i) }
+                    if let n = v as? NSNumber { return n.int64Value }
+                    return nil
+                }
+            }
+            return Raw(
                 id: row.int64(0),
-                type: Chat.ChatType.from(rawInt: row.int(1)),
-                displayName: name,
+                type: row.int(1),
+                chatName: nonEmpty(row.string(2)),
+                direct: nonEmpty(row.string(7)) ?? nonEmpty(row.string(8)) ?? nonEmpty(row.string(9)),
+                link: nonEmpty(row.string(10)),
+                memberIds: members,
                 memberCount: row.int(3),
-                lastMessageId: row.optionalInt64(4),
-                lastMessageAt: row.optionalKakaoDate(5),
-                unreadCount: row.int(6)
+                lastMsgId: row.optionalInt64(4),
+                lastMsgAt: row.optionalKakaoDate(5),
+                unread: row.int(6)
+            )
+        }
+
+        // Second pass: resolve userIds for chats that still need a name.
+        let needsMembers = raws.filter { r in
+            r.chatName == nil && r.direct == nil && r.link == nil && r.type != 5 && !r.memberIds.isEmpty
+        }
+        let allIds = Set(needsMembers.flatMap { $0.memberIds })
+        var nameById: [Int64: String] = [:]
+        if !allIds.isEmpty {
+            let placeholders = Array(repeating: "?", count: allIds.count).joined(separator: ",")
+            let userSql = """
+                SELECT userId, COALESCE(NULLIF(displayName,''), NULLIF(friendNickName,''), NULLIF(nickName,'')) AS name
+                FROM NTUser
+                WHERE linkId = 0 AND userId IN (\(placeholders))
+                """
+            let binds: [SQLValue] = allIds.map { .int(Int($0)) }
+            let pairs: [(Int64, String)] = try query(userSql, bind: binds) { r in
+                guard let n = r.string(1) else { return (r.int64(0), "") }
+                return (r.int64(0), n)
+            }
+            for (uid, n) in pairs where !n.isEmpty { nameById[uid] = n }
+        }
+
+        // Assemble final Chat list.
+        return raws.map { r in
+            let selfLabel: String? = (r.type == 5) ? "Self-chat (Notes)"
+                : (r.type >= 9999 || r.id < 0) ? "(system)"
+                : nil
+            var groupLabel: String? = nil
+            if selfLabel == nil, r.chatName == nil, r.direct == nil, r.link == nil, !r.memberIds.isEmpty {
+                let resolved = r.memberIds.compactMap { nameById[$0] }
+                if !resolved.isEmpty {
+                    let head = resolved.prefix(3).joined(separator: ", ")
+                    let hidden = r.memberCount - resolved.count - 1  // -1 for self
+                    let extra = hidden > 0 ? " +\(hidden) more" : ""
+                    groupLabel = head + extra
+                }
+            }
+            let name = selfLabel ?? r.chatName ?? r.direct ?? r.link ?? groupLabel ?? "(unknown)"
+            return Chat(
+                id: r.id,
+                type: Chat.ChatType.from(rawInt: r.type),
+                displayName: name,
+                memberCount: r.memberCount,
+                lastMessageId: r.lastMsgId,
+                lastMessageAt: r.lastMsgAt,
+                unreadCount: r.unread
             )
         }
     }
@@ -339,6 +407,13 @@ public final class DatabaseReader: @unchecked Sendable {
         func string(_ col: Int32) -> String? {
             guard let ptr = sqlite3_column_text(stmt, col) else { return nil }
             return String(cString: ptr)
+        }
+
+        func blob(_ col: Int32) -> Data? {
+            guard let ptr = sqlite3_column_blob(stmt, col) else { return nil }
+            let n = Int(sqlite3_column_bytes(stmt, col))
+            guard n > 0 else { return nil }
+            return Data(bytes: ptr, count: n)
         }
 
         func bool(_ col: Int32) -> Bool {


### PR DESCRIPTION
## Summary

Most rooms surfaced by `kakaocli chats` currently render as `(unknown)` because `DatabaseReader.chats()`:

1. Only joins `NTUser` on `directChatMemberUserId` — no path for open chats (type 4) or plain group chats (type 2/3).
2. Treats empty `chatName` strings as valid names (Swift `??` only falls back on nil, not `""`).
3. Has no handling for the self-chat (type 5) or the system pseudo-rows (type ≥ 9999 / `chatId < 0`).

On a live account with 2,932 rooms, the default output before this change was dominated by `(unknown)`; after, it is zero.

## Changes (single file, `DatabaseReader.swift`)

- `LEFT JOIN NTOpenLink ol ON r.linkId = ol.linkId AND r.linkId != 0` — resolves open-chat `linkName`.
- Parse `NTChatRoom.displayMemberIds` (an `NSArray<NSNumber>` stored as a `bplist00` blob) via `PropertyListSerialization`, then a **single batched** ``SELECT userId, COALESCE(NULLIF(displayName,''), ...) FROM NTUser WHERE linkId = 0 AND userId IN (?, ?, ...)`` — avoids N+1 when `--limit` is large.
- `nonEmpty()` helper: treat `\"\"` like nil so fallbacks actually fire.
- Explicit labels: type 5 → `Self-chat (Notes)`, type ≥ 9999 or `chatId < 0` → `(system)`.
- New `Row.blob()` accessor on the internal SQLite wrapper.

Resolution priority:

```
selfLabel → chatName → direct → openLink → group members → (unknown)
```

Group labels list up to 3 resolved member names with a `+N more` suffix when `activeMembersCount` exceeds what the plist stored. The `-1` in the hidden-count math accounts for KakaoTalk usually omitting self from `displayMemberIds`.

## Example diff (real room, 2-person group)

**Before**
```
[4688379955035143] (unknown) (no unread) 14:40
```

**After**
```
[4688379955035143] 카카오뱅크 14:40
```

## Test plan

- [x] `swift build -c release` clean on Swift 6.3.1 (swift.org toolchain) / macOS 15 arm64
- [x] Live DB with 2,932 rooms across type codes 0/1/2/3/4/5/9999/10001: `kakaocli chats --limit 9999 | grep -c '(unknown)'` → `0`
- [x] Open chats resolve to `linkName` (e.g. `에어비앤비 호스트모임 /삼삼엠투/리브애니웨어/미스터멘션`)
- [x] Group chats resolve to member names (e.g. `지강, 원혜연, 김사무엘맘`)
- [x] Self-chat labels as `Self-chat (Notes)`
- [x] `chatId = -2` (type 10001) labels as `(system)` instead of `(unknown)`

## Notes for reviewers

- bplist parsing is defensive (`try?` + optional casts) so a malformed blob falls through to `(unknown)` instead of throwing.
- The group-chat member lookup is skipped when a higher-priority label already wins, so there's no DB work for direct/open/named rooms.
- No behavior change for rooms whose `chatName` was already populated correctly.