### PR TITLE
fix: avoid AX tree storms on logged-in Main Window (KakaoTalk 26.x)

### DIFF
--- a/Sources/KakaoCore/Automation/AppLifecycle.swift
+++ b/Sources/KakaoCore/Automation/AppLifecycle.swift
@@ -28,36 +28,52 @@ public enum AppLifecycle {
     /// Set `aggressive: true` to try showing the window if hidden (slower, has side effects).
     /// Use `aggressive: false` when polling during login to avoid interfering.
     public static func detectState(aggressive: Bool = true) -> KakaoAppState {
+        let debug = ProcessInfo.processInfo.environment["KAKAOCLI_DEBUG"] != nil
+        func dlog(_ s: String) { if debug { fputs("[detectState] \(s)\n", stderr) } }
+        dlog("begin aggressive=\(aggressive)")
         guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first else {
+            dlog("not running")
             return .notRunning
         }
 
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        dlog("got axApp, calling windows()")
         var windows = AXHelpers.windows(axApp)
+        dlog("windows.count=\(windows.count)")
 
         if windows.isEmpty && aggressive {
             // KakaoTalk hides its window when "closed" (still running in menu bar).
             // Activate it to make windows visible, then re-check.
+            dlog("empty + aggressive: activating")
             app.activate()
             Thread.sleep(forTimeInterval: 0.5)
             windows = AXHelpers.windows(axApp)
+            dlog("after activate windows.count=\(windows.count)")
         }
 
         if windows.isEmpty && aggressive {
             // Still no windows — try to show the main window via status bar menu.
+            dlog("still empty, showing main window via menu")
             showMainWindow(axApp)
             Thread.sleep(forTimeInterval: 1.0)
             windows = AXHelpers.windows(axApp)
+            dlog("after showMainWindow windows.count=\(windows.count)")
         }
 
         // Check for real AXWindow elements first
+        dlog("filtering real windows by role")
         let realWindows = windows.filter { AXHelpers.role($0) == "AXWindow" }
+        dlog("realWindows.count=\(realWindows.count)")
         if !realWindows.isEmpty {
             // Prioritize Main Window for classification
             if let mainWindow = realWindows.first(where: { AXHelpers.identifier($0) == "Main Window" }) {
-                return classifyWindow(mainWindow)
+                dlog("classifying Main Window")
+                let r = classifyWindow(mainWindow)
+                dlog("classifyWindow returned \(r)")
+                return r
             }
             // Non-Main-Window windows are chat windows → we're logged in
+            dlog("no Main Window, but have realWindows → loggedIn")
             return .loggedIn
         }
 
@@ -85,11 +101,17 @@ public enum AppLifecycle {
             if title.lowercased().contains("log in") || title == "로그인" {
                 return .loginScreen
             }
-            if AXHelpers.findFirst(window, role: "AXImage", identifier: "Logo") != nil {
-                return .loginScreen
-            }
+            // Fast positive check first: if the chat list table exists (shallow 2-level lookup),
+            // we're logged in. This avoids an expensive full-tree Logo search on logged-in
+            // windows, which becomes pathological when AXManualAccessibility forces eager
+            // construction of the entire chat list subtree (hundreds of rows).
             if AXHelpers.chatListTable(window) != nil {
                 return .loggedIn
+            }
+            // Fallback login detection: bounded-depth Logo lookup (Logo sits near window root
+            // on the login screen, so depth 4 is more than enough).
+            if AXHelpers.findFirst(window, role: "AXImage", identifier: "Logo", maxDepth: 4) != nil {
+                return .loginScreen
             }
             return .loggedIn
         }

--- a/Sources/KakaoCore/Automation/KakaoAutomator.swift
+++ b/Sources/KakaoCore/Automation/KakaoAutomator.swift
@@ -10,21 +10,33 @@ public final class KakaoAutomator {
 
     /// Send a message to a chat by navigating the UI.
     public func sendMessage(to chatName: String, message: String, selfChat: Bool = false) throws {
+        let debug = ProcessInfo.processInfo.environment["KAKAOCLI_DEBUG"] != nil
+        func dlog(_ s: String) { if debug { fputs("[send] \(s)\n", stderr) } }
+
+        dlog("step1 ensureReady begin")
         // 1. Ensure KakaoTalk is running and logged in
         let stateBefore = AppLifecycle.detectState()
+        dlog("step1 stateBefore=\(stateBefore)")
         try AppLifecycle.ensureReady(credentials: CredentialStore())
         if stateBefore != .loggedIn {
             Thread.sleep(forTimeInterval: 2.0)
         }
+        dlog("step1 done")
 
         // 2. Activate KakaoTalk and get windows
         try AXHelpers.activateApp(bundleId: Self.bundleId)
         let app = try AXHelpers.appElement(bundleId: Self.bundleId)
 
         let windows = AXHelpers.windows(app)
+        dlog("step2 windows.count=\(windows.count)")
+        for (i, w) in windows.enumerated() {
+            dlog("  window[\(i)] role=\(AXHelpers.role(w) ?? "?") id=\(AXHelpers.identifier(w) ?? "?") title=\(AXHelpers.title(w) ?? "?")")
+        }
         guard let mainWindow = windows.first(where: { AXHelpers.identifier($0) == "Main Window" }) else {
+            dlog("step2 FAIL: no 'Main Window' identifier found")
             throw AutomationError.noWindows
         }
+        dlog("step2 mainWindow found")
 
         // 3. Close any existing chat windows to avoid sending to the wrong one
         for w in windows where AXHelpers.identifier(w) != "Main Window" {
@@ -33,30 +45,44 @@ public final class KakaoAutomator {
         if windows.count > 1 {
             Thread.sleep(forTimeInterval: 0.3)
         }
+        dlog("step3 closed non-main windows")
 
-        // 4. Ensure we're on the Chats tab
-        if let chatroomsTab = AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms") {
+        // 4. Ensure we're on the Chats tab.
+        // The sidebar tabs are direct children of the main window (AXButton id="chatrooms"
+        // in current KakaoTalk Mac; older builds exposed it as AXCheckBox). Cap search depth
+        // so this stays cheap even when the chat list subtree is huge under
+        // AXManualAccessibility.
+        let chatroomsTab =
+            AXHelpers.findFirst(mainWindow, role: "AXButton", identifier: "chatrooms", maxDepth: 3) ??
+            AXHelpers.findFirst(mainWindow, role: "AXCheckBox", identifier: "chatrooms", maxDepth: 3)
+        if let chatroomsTab {
             _ = AXHelpers.performAction(chatroomsTab, kAXPressAction as String)
             Thread.sleep(forTimeInterval: 0.3)
         }
+        dlog("step4 chats tab ensured (found=\(chatroomsTab != nil))")
 
         // 5. Find the chat row in the list
         guard let table = AXHelpers.chatListTable(mainWindow) else {
+            dlog("step5 FAIL: chatListTable(mainWindow) returned nil")
             throw AutomationError.chatNotFound(chatName)
         }
+        dlog("step5 chat list table found, searching row selfChat=\(selfChat)")
 
         let row: AXUIElement
         if selfChat {
             guard let selfRow = AXHelpers.findSelfChatRow(table) else {
+                dlog("step5 FAIL: findSelfChatRow nil")
                 throw AutomationError.chatNotFound("self-chat (나와의 채팅)")
             }
             row = selfRow
         } else {
             guard let chatRow = AXHelpers.findChatRow(table, chatName: chatName) else {
+                dlog("step5 FAIL: findChatRow(\(chatName)) nil")
                 throw AutomationError.chatNotFound(chatName)
             }
             row = chatRow
         }
+        dlog("step5 row found")
 
         // 6. Open the chat via AX row selection + Enter (works even when off-screen).
         //    Falls back to scroll-into-view + double-click if selection fails.
@@ -67,6 +93,7 @@ public final class KakaoAutomator {
             Thread.sleep(forTimeInterval: 0.5)
             let checkWindows = AXHelpers.windows(app)
             opened = checkWindows.contains { AXHelpers.identifier($0) != "Main Window" }
+            dlog("step6 selectRow+Enter opened=\(opened)")
         }
         if !opened {
             if let scrollArea = AXHelpers.chatListScrollArea(mainWindow) {
@@ -74,6 +101,7 @@ public final class KakaoAutomator {
                 Thread.sleep(forTimeInterval: 0.3)
             }
             AXHelpers.doubleClickElement(row)
+            dlog("step6 fallback double-click")
         }
 
         // 7. Wait for the chat window to appear
@@ -86,13 +114,33 @@ public final class KakaoAutomator {
             if chatWindow != nil { break }
         }
         guard let chatWindow else {
+            dlog("step7 FAIL: chat window did not appear within 5s")
             throw AutomationError.inputFieldNotFound
         }
+        dlog("step7 chatWindow role=\(AXHelpers.role(chatWindow) ?? "?") title=\(AXHelpers.title(chatWindow) ?? "?")")
 
         // 8. Find the message input field
+        // Dump children for debug
+        if debug {
+            let kids = AXHelpers.children(chatWindow)
+            dlog("step8 chatWindow.children.count=\(kids.count)")
+            for (i, k) in kids.enumerated() {
+                let rl = AXHelpers.role(k) ?? "?"
+                let ds = AXHelpers.description(k) ?? ""
+                dlog("  child[\(i)] role=\(rl) desc=\(ds)")
+                if rl == "AXScrollArea" {
+                    let subs = AXHelpers.children(k)
+                    for (j, s) in subs.enumerated() {
+                        dlog("    scroll_child[\(j)] role=\(AXHelpers.role(s) ?? "?") desc=\(AXHelpers.description(s) ?? "")")
+                    }
+                }
+            }
+        }
         guard let inputField = findInputField(in: chatWindow) else {
+            dlog("step8 FAIL: findInputField returned nil")
             throw AutomationError.inputFieldNotFound
         }
+        dlog("step8 inputField found role=\(AXHelpers.role(inputField) ?? "?") desc=\(AXHelpers.description(inputField) ?? "")")
 
         // 9. Focus and type the message
         _ = AXHelpers.performAction(chatWindow, kAXRaiseAction as String)
@@ -150,7 +198,17 @@ public enum AutomationError: Error, CustomStringConvertible {
         case .chatNotFound(let name):
             return "Chat '\(name)' not found in the chat list"
         case .inputFieldNotFound:
-            return "Could not find the message input field"
+            return """
+            Could not find the message input field.
+
+            Recent KakaoTalk Mac builds (v26.x+) do not expose their AX hierarchy by \
+            default. To enable it, run:
+
+              defaults write com.kakao.KakaoTalkMac AXManualAccessibility -bool true
+              osascript -e 'quit app "KakaoTalk"' && sleep 2 && open -a KakaoTalk
+
+            After re-logging in, retry. Re-run with KAKAOCLI_DEBUG=1 for verbose traces.
+            """
         case .sendFailed(let msg):
             return "Failed to send message: \(msg)"
         }


### PR DESCRIPTION
## Summary

`kakaocli send` hangs indefinitely on recent KakaoTalk Mac builds (verified on **26.3.0 build 1170**) when the user has `AXManualAccessibility=true` and a non-trivial chat history. Bisected to two unbounded recursive AX searches that traverse the entire eagerly-constructed chat-list subtree.

## Repro

```bash
defaults write com.kakao.KakaoTalkMac AXManualAccessibility -bool true
osascript -e 'quit app "KakaoTalk"' && sleep 2 && open -a KakaoTalk
# log in, have any reasonably-sized chat list (hundreds of chats)
kakaocli send --me _ "hello"
# hangs past 60s, no output; must SIGKILL
```

Before the fix, `KAKAOCLI_DEBUG=1 kakaocli send --me _ "..."` never gets past `classifyWindow`.

## Root cause

Two AX probes on the logged-in main window default to `maxDepth: 10` with no hit, so they walk the entire chat-list subtree — hundreds of rows, each with cells/buttons/images — multiple times per send:

1. **`AppLifecycle.classifyWindow`** checks `AXImage` id=`Logo` *before* the fast `chatListTable()` check. On a logged-in window the logo doesn't exist, so the lookup visits every descendant.
2. **`KakaoAutomator.sendMessage`** step 4 looks for the chats tab as `AXCheckBox` id=`chatrooms`, but current KakaoTalk exposes it as `AXButton` id=`chatrooms`. The role mismatch turns `findFirst` into another full-tree scan, same pathology.

Both were fast in the legacy AX hierarchy (Logo was the only thing in a login-screen main window; chats tab used to be `AXCheckBox`) but regressed once KakaoTalk 26.x changed the tree shape + users started enabling `AXManualAccessibility` to work around the input-field discovery issue.

## Fix

- **Reorder `classifyWindow`**: run the shallow `chatListTable` positive check first; fall back to a depth-4-capped Logo lookup for login detection (Logo sits near the window root).
- **Match the chats tab by `AXButton` first**, with an `AXCheckBox` legacy fallback — both capped at `maxDepth: 3` since tabs are direct children of the window.
- **Improve the `.inputFieldNotFound` error** to tell users how to enable `AXManualAccessibility`. On current KakaoTalk builds the message input field isn't in the AX tree at all without it, so the plain "Could not find the message input field" message leaves users stuck.
- **Gate per-step tracing behind `KAKAOCLI_DEBUG=1`** so the next round of KakaoTalk AX regressions can be triaged without a rebuild.

No behavior change for users who had this working — the legacy login-screen and legacy chats-tab roles still match via fallbacks.

## Verification

On KakaoTalk 26.3.0 build 1170 / macOS Darwin 25.2 / kakaocli fork:

| | Before | After |
|---|---|---|
| `kakaocli send --me _ "..."` | hangs > 60s | **3.8s, success** |

```
$ time kakaocli send --me _ "[final 13:24:09]"
Message sent to 'self-chat'.
kakaocli send --me _ ...  0.03s user 0.02s system 1% cpu 3.810 total
```

With `KAKAOCLI_DEBUG=1` the full trace is visible for future triage:
```
[send] step1 ensureReady begin
[detectState] classifyWindow returned loggedIn
[send] step4 chats tab ensured (found=true)
[send] step5 row found
[send] step6 selectRow+Enter opened=true
[send] step7 chatWindow role=AXWindow title=형준
[send] step8 inputField found role=AXTextArea desc=메시지 입력
Message sent to 'self-chat'.
```

## Test plan

- [x] `swift build` clean (warnings unchanged)
- [x] `kakaocli send --me _ "..."` end-to-end on KakaoTalk 26.3.0
- [x] Open-chat substring match (`kakaocli send "파리스피치" "..."`) — manual AppleScript equivalent verified; kakaocli path now reaches `findInputField` consistently
- [x] `KAKAOCLI_DEBUG=1` tracing surfaces each step
- [x] Error message displays correct `defaults write` command when `AXManualAccessibility` is disabled

Happy to follow up with a separate PR that auto-enables `AXManualAccessibility` on first run if the maintainers want that UX.