### PR TITLE
fix(harvest): drop hardcoded `_NS:18` AX identifier for chat-name lookup

### DIFF
--- a/Sources/KakaoCore/Automation/ChatHarvester.swift
+++ b/Sources/KakaoCore/Automation/ChatHarvester.swift
@@ -209,13 +209,19 @@ public enum ChatHarvester {
     // MARK: - Private Helpers
 
     /// Extract the display name from a chat list row.
+    /// KakaoTalk Mac 26.x changed the AppKit auto-generated AX identifier of the
+    /// chat-name text label, so the previous `_NS:18` match no longer fires.
+    /// In the current cell layout (button, image, name, member-count, time,
+    /// preview-area, unread, badge) the chat name is the first non-empty
+    /// AXStaticText — it appears before purely numeric labels (member count,
+    /// unread) and before the time label.
     private static func extractName(from row: AXUIElement) -> String {
         for cell in AXHelpers.children(row) {
             guard AXHelpers.role(cell) == "AXCell" else { continue }
             for child in AXHelpers.children(cell) {
-                if AXHelpers.role(child) == "AXStaticText" && AXHelpers.identifier(child) == "_NS:18" {
-                    return AXHelpers.value(child) ?? "(unknown)"
-                }
+                guard AXHelpers.role(child) == "AXStaticText" else { continue }
+                guard let val = AXHelpers.value(child), !val.isEmpty else { continue }
+                return val
             }
         }
         return "(unknown)"


### PR DESCRIPTION
Why
---
KakaoTalk Mac 26.x ships a slightly different view hierarchy under each chat-list `AXCell`, so the AppKit auto-generated identifier the harvester matched against (`_NS:18`) no longer points to the chat-name `AXStaticText`. With the hardcoded match in place, every harvested chat resolves to `(unknown)` even though the AX tree still exposes the real name; the metadata store and downstream `chats --json` then keep returning `display_name: "(unknown)"` for group chats indefinitely.

`_NS:` identifiers are an AppKit implementation detail tied to view declaration order and shift whenever Apple or KakaoTalk reorganizes subviews. Pinning the harvester to a specific number is fragile by construction.

Fix
---
Drop the identifier match. In the cell layout (`button, image, name, member-count, time, preview-area, unread, badge`) the chat name is the first non-empty `AXStaticText`, ahead of the purely numeric labels (member count, unread count) and the time label. Returning that first non-empty value resolves the regression on KakaoTalk 26.x without relying on a fragile internal identifier.

Verification
------------
Tested locally on macOS 26.0 / KakaoTalk 26.3.0 with kakaocli built off v0.6.0 plus this patch:
- Pre-patch: every row returned `(unknown)`; metadata.json saved `"name": "(unknown)"` for all 50 harvested chats.
- Post-patch: real names (Hangul + emoji) appear in summary and metadata.json; `Found N chats in UI` matches DB count.