### PR TITLE
fix(sync): filter logId=Int64.max placeholder to prevent cursor wedge

### DIFF
--- a/Sources/KakaoCore/Database/DatabaseReader.swift
+++ b/Sources/KakaoCore/Database/DatabaseReader.swift
@@ -193,7 +193,12 @@ public final class DatabaseReader: @unchecked Sendable {
 
     /// Get the maximum logId in the messages table (used by DatabaseWatcher).
     public func maxLogId() throws -> Int64 {
-        let results = try query("SELECT MAX(logId) FROM NTChatMessage", bind: []) { row in
+        // logId = Int64.max는 KakaoTalk Mac의 in-flight placeholder (서버 ack 전).
+        // 그 값을 cursor seed로 잡으면 sync가 즉시 silent wedge 상태에 빠짐.
+        let results = try query(
+            "SELECT MAX(logId) FROM NTChatMessage WHERE logId != ?",
+            bind: [.int64(Int64.max)]
+        ) { row in
             row.optionalInt64(0)
         }
         return results.first.flatMap { $0 } ?? 0

--- a/Sources/KakaoCore/Sync/DatabaseWatcher.swift
+++ b/Sources/KakaoCore/Sync/DatabaseWatcher.swift
@@ -37,11 +37,17 @@ public final class DatabaseWatcher: @unchecked Sendable {
         while running {
             do {
                 let messages = try fetchNewMessages()
-                if !messages.isEmpty {
-                    if let maxId = messages.map(\.logId).max() {
+                // KakaoTalk Mac은 송신 직후·서버 ack 전 상태의 메시지를 NTChatMessage에
+                // logId = Int64.max 임시 placeholder로 저장한다. 그 행을 cursor에 반영하면
+                // 이후 messagesSince(logId > Int64.max)가 영원히 빈 결과를 돌려줘 sync가
+                // silent wedge 상태에 빠진다. 다음 polling에서 실제 logId로 갱신된 같은
+                // 메시지를 다시 emit하므로 누락 위험도 없음.
+                let valid = messages.filter { $0.logId != Int64.max }
+                if !valid.isEmpty {
+                    if let maxId = valid.map(\.logId).max() {
                         lastLogId = maxId
                     }
-                    onMessages(messages)
+                    onMessages(valid)
                 }
             } catch {
                 onError(error)


### PR DESCRIPTION
KakaoTalk Mac persists in-flight (server-ack pending) outgoing messages in NTChatMessage with logId = Int64.max as a temporary placeholder. If DatabaseWatcher updates its lastLogId cursor from such a row, every subsequent messagesSince(logId > ?) query becomes WHERE logId > Int64.max, which is always empty — sync enters a silent wedge state until the process restarts, even though the polling loop keeps running and no error is raised.

Repro
-----
Send two messages via kakaocli send in quick succession (~1s apart) while kakaocli sync --follow runs. The second send's echo is picked up before KakaoTalk receives server ack, sync emits a SyncMessage with log_id: 9223372036854775807, and from that point onwards no new messages reach the webhook. Field-observed on a bot integrating kakaocli sync via webhook (vaaxbot, ~10h runtime).

Fix
---
- DatabaseWatcher: filter rows with logId == Int64.max out of both the emission batch and the cursor-max calculation. The same message is re-read on the next poll once KakaoTalk updates the row with the real server-assigned logId, so no events are lost.
- DatabaseReader.maxLogId(): exclude Int64.max rows from the MAX(logId) query so that startup cursor seed cannot be poisoned if a placeholder is already in the table when sync starts.

Tests
-----
Existing swift test 4/4 still passes. No new unit test added: the failure requires a live KakaoTalk Mac UI in a specific timing window; a deterministic test would need a recorded SQLite fixture with a placeholder row, which is left as follow-up.