### PR TITLE
fix: prevent auth hangs and link SQLCipher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,12 @@
 // swift-tools-version: 6.0
 
+import Foundation
 import PackageDescription
+
+let sqlcipherPrefix = ProcessInfo.processInfo.environment["SQLCIPHER_PREFIX"]
+    ?? ["/opt/homebrew/opt/sqlcipher", "/usr/local/opt/sqlcipher"]
+        .first { FileManager.default.fileExists(atPath: "\($0)/include/sqlcipher/sqlite3.h") }
+    ?? "/opt/homebrew/opt/sqlcipher"
 
 let package = Package(
     name: "kakaocli",
@@ -22,7 +28,18 @@ let package = Package(
         ),
         .target(
             name: "KakaoCore",
-            dependencies: ["CSQLCipher"]
+            dependencies: ["CSQLCipher"],
+            swiftSettings: [
+                .unsafeFlags(["-Xcc", "-I\(sqlcipherPrefix)/include"]),
+            ],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-L\(sqlcipherPrefix)/lib",
+                    "-lsqlcipher",
+                    "-Xlinker", "-rpath",
+                    "-Xlinker", "\(sqlcipherPrefix)/lib",
+                ]),
+            ]
         ),
         .systemLibrary(
             name: "CSQLCipher",

--- a/Sources/KakaoCLI/Commands/AuthCommand.swift
+++ b/Sources/KakaoCLI/Commands/AuthCommand.swift
@@ -11,6 +11,9 @@ struct AuthCommand: ParsableCommand {
     @Flag(name: .long, help: "Show derived values (key, db name) for debugging")
     var verbose = false
 
+    @Flag(name: .long, help: "Force userId re-discovery by clearing the cache before running")
+    var refresh = false
+
     @Option(name: .long, help: "Override user ID instead of reading from plist")
     var userId: Int?
 
@@ -18,6 +21,11 @@ struct AuthCommand: ParsableCommand {
     var uuid: String?
 
     func run() throws {
+        // 0. If --refresh, clear cached userId before any discovery
+        if refresh {
+            DeviceInfo.clearUserIdCache()
+        }
+
         // 1. Get device UUID
         let deviceUUID: String
         if let override = uuid {

--- a/Sources/KakaoCore/Database/DeviceInfo.swift
+++ b/Sources/KakaoCore/Database/DeviceInfo.swift
@@ -4,6 +4,30 @@ import Foundation
 /// Extracts device UUID and KakaoTalk user ID from the local system.
 public enum DeviceInfo {
 
+    /// In-process cache for the discovered user ID.
+    nonisolated(unsafe) static var cachedUserId: Int? = nil
+
+    /// Path to the on-disk user ID cache file.
+    public static var userIdCachePath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.kakaocli/userid"
+    }
+
+    /// Persist the user ID to disk and in-process cache.
+    static func saveUserIdCache(_ id: Int) {
+        cachedUserId = id
+        let path = userIdCachePath
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? String(id).write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    /// Clear both the in-process cache and the on-disk cache file.
+    public static func clearUserIdCache() {
+        cachedUserId = nil
+        try? FileManager.default.removeItem(atPath: userIdCachePath)
+    }
+
     /// Get the IOPlatformUUID from IORegistry.
     public static func platformUUID() throws -> String {
         let process = Process()
@@ -52,11 +76,26 @@ public enum DeviceInfo {
     /// Extract user ID from the KakaoTalk preferences plist.
     ///
     /// Tries multiple strategies in order:
+    /// 0. In-process cache, then on-disk cache (~/.kakaocli/userid)
     /// 1. FSChatWindowTransparency common suffix (legacy)
     /// 2. Direct key lookup (userId, user_id, etc.)
     /// 3. Recover userId by reversing SHA-512 hash from plist revision keys
     /// 4. FSChatWindowFrame_ common suffix
     public static func userId() throws -> Int {
+        // Strategy 0: Return from in-process cache first
+        if let cached = cachedUserId {
+            return cached
+        }
+
+        // Strategy 0b: Read from on-disk cache
+        let cachePath = userIdCachePath
+        if FileManager.default.fileExists(atPath: cachePath),
+           let contents = try? String(contentsOfFile: cachePath, encoding: .utf8),
+           let id = Int(contents.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            cachedUserId = id
+            return id
+        }
+
         let plistPaths = [containerPreferencesPath, preferencesPath]
         for plistPath in plistPaths {
             guard FileManager.default.fileExists(atPath: plistPath) else { continue }
@@ -73,6 +112,7 @@ public enum DeviceInfo {
             if fsChatKeys.count >= 2 {
                 let suffixes = fsChatKeys.map { String($0.dropFirst(transparencyPrefix.count)) }
                 if let commonSuffix = longestCommonSuffix(suffixes), let id = Int(commonSuffix) {
+                    saveUserIdCache(id)
                     return id
                 }
             }
@@ -80,8 +120,14 @@ public enum DeviceInfo {
             // Strategy 2: Direct key lookup
             let candidateKeys = ["userId", "user_id", "KAKAO_USER_ID", "userID"]
             for key in candidateKeys {
-                if let id = plist[key] as? Int { return id }
-                if let str = plist[key] as? String, let id = Int(str) { return id }
+                if let id = plist[key] as? Int {
+                    saveUserIdCache(id)
+                    return id
+                }
+                if let str = plist[key] as? String, let id = Int(str) {
+                    saveUserIdCache(id)
+                    return id
+                }
             }
 
             // Strategy 3: Recover userId from SHA-512 hash in plist revision keys.
@@ -90,6 +136,7 @@ public enum DeviceInfo {
             // We brute-force the pre-image since userIds are typically small integers.
             if let hash = activeAccountHash(from: plist) {
                 if let id = recoverUserIdFromSHA512(hexHash: hash) {
+                    saveUserIdCache(id)
                     return id
                 }
             }
@@ -100,6 +147,7 @@ public enum DeviceInfo {
             if frameKeys.count >= 2 {
                 let suffixes = frameKeys.map { String($0.dropFirst(framePrefix.count)) }
                 if let commonSuffix = longestCommonSuffix(suffixes), let id = Int(commonSuffix) {
+                    saveUserIdCache(id)
                     return id
                 }
             }

--- a/Sources/KakaoCore/Database/DeviceInfo.swift
+++ b/Sources/KakaoCore/Database/DeviceInfo.swift
@@ -242,19 +242,21 @@ public enum DeviceInfo {
     /// Recover a userId by brute-forcing the SHA-512 pre-image.
     /// KakaoTalk stores SHA-512(userId) as hex in plist keys. Since userIds are
     /// typically small integers, this is fast (< 1 second for IDs under 1M).
-    /// Searches up to 1 billion with a 10-second timeout.
+    /// Searches up to 4 billion with a 300-second timeout.
     public static func recoverUserIdFromSHA512(hexHash: String) -> Int? {
         guard hexHash.count == 128 else { return nil }
         // Parse target hash to bytes
         var targetBytes = [UInt8](repeating: 0, count: 64)
-        var hexChars = Array(hexHash)
+        let hexChars = Array(hexHash)
         for i in 0..<64 {
             guard let byte = UInt8(String(hexChars[i*2...i*2+1]), radix: 16) else { return nil }
             targetBytes[i] = byte
         }
 
+        fputs("Could not find user ID from plist. Starting SHA-512 brute-force search (this may take a few minutes)...\n", stderr)
+
         let startTime = CFAbsoluteTimeGetCurrent()
-        let maxId = 1_000_000_000
+        let maxId = 4_000_000_000
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA512_DIGEST_LENGTH))
 
         for i in 0..<maxId {
@@ -262,11 +264,17 @@ public enum DeviceInfo {
             let data = Array(s.utf8)
             CC_SHA512(data, CC_LONG(data.count), &hash)
             if hash == targetBytes {
+                let elapsed = Int(CFAbsoluteTimeGetCurrent() - startTime)
+                fputs("Found user ID: \(i) (cached to ~/.kakaocli/userid)\n", stderr)
+                _ = elapsed  // suppress unused warning; elapsed logged above via Found message
                 return i
             }
-            // Timeout after 10 seconds
+            // Progress + timeout every 5M iterations
             if i % 5_000_000 == 0 && i > 0 {
-                if CFAbsoluteTimeGetCurrent() - startTime > 10 { return nil }
+                let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+                let millions = i / 1_000_000
+                fputs("  Searching... \(millions)m checked (\(Int(elapsed))s)\n", stderr)
+                if elapsed > 300 { return nil }
             }
         }
         return nil

--- a/Sources/KakaoCore/Database/DeviceInfo.swift
+++ b/Sources/KakaoCore/Database/DeviceInfo.swift
@@ -242,7 +242,7 @@ public enum DeviceInfo {
     /// Recover a userId by brute-forcing the SHA-512 pre-image.
     /// KakaoTalk stores SHA-512(userId) as hex in plist keys. Since userIds are
     /// typically small integers, this is fast (< 1 second for IDs under 1M).
-    /// Searches up to 4 billion with a 300-second timeout.
+    /// Searches up to 1 billion with a 300-second timeout.
     public static func recoverUserIdFromSHA512(hexHash: String) -> Int? {
         guard hexHash.count == 128 else { return nil }
         // Parse target hash to bytes
@@ -256,7 +256,7 @@ public enum DeviceInfo {
         fputs("Could not find user ID from plist. Starting SHA-512 brute-force search (this may take a few minutes)...\n", stderr)
 
         let startTime = CFAbsoluteTimeGetCurrent()
-        let maxId = 4_000_000_000
+        let maxId = 1_000_000_000
         var hash = [UInt8](repeating: 0, count: Int(CC_SHA512_DIGEST_LENGTH))
 
         for i in 0..<maxId {

--- a/Sources/KakaoCore/Database/DeviceInfo.swift
+++ b/Sources/KakaoCore/Database/DeviceInfo.swift
@@ -36,9 +36,13 @@ public enum DeviceInfo {
         let pipe = Pipe()
         process.standardOutput = pipe
         try process.run()
+
+        // Drain stdout before waiting so verbose ioreg output cannot fill the pipe
+        // and block the child process while we wait for it to exit.
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
-        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let output = String(data: data, encoding: .utf8) ?? ""
         // Parse: "IOPlatformUUID" = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
         guard let range = output.range(of: #""IOPlatformUUID" = "([^"]+)""#, options: .regularExpression),
               let uuidRange = output[range].range(of: #"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}"#, options: .regularExpression)


### PR DESCRIPTION
## Summary

Fixes several auth-path failures that can make `kakaocli auth` hang or fail even when SQLCipher is installed:

- cache the discovered KakaoTalk user ID and add `auth --refresh` to force rediscovery
- add progress logging and a longer bounded timeout for SHA-512 user ID recovery
- prevent `platformUUID()` from deadlocking by draining `ioreg` stdout before waiting for process exit
- explicitly link the SwiftPM build against Homebrew SQLCipher instead of Apple system SQLite

## Root Cause

`platformUUID()` waited for `ioreg` to exit before reading from its stdout pipe. On systems where `ioreg` emits enough data to fill the pipe, the child process blocks and `kakaocli auth` appears to hang before printing anything.

Separately, SwiftPM was importing SQLite symbols through the SQLCipher system-library target but the final executable could still link `/usr/lib/libsqlite3.dylib`. In that state, `PRAGMA key` does not actually decrypt SQLCipher databases, so auth fails with a misleading “install sqlcipher” message even after `brew install sqlcipher`.

## Validation

- `swift test`
- `swift build -c release`
- `otool -L .build/release/kakaocli` shows `/opt/homebrew/opt/sqlcipher/lib/libsqlcipher.dylib`
- `kakaocli auth` opens the local KakaoTalk database successfully and lists tables
