### PR TITLE
Fix: match chat-list rows by name label, not hardcoded _NS:18 identifier

### DIFF
--- a/Sources/KakaoCore/Automation/AXHelpers.swift
+++ b/Sources/KakaoCore/Automation/AXHelpers.swift
@@ -187,19 +187,23 @@ public enum AXHelpers {
     }
 
     /// Find the AXRow in a chat list whose name label matches the given text.
-    /// KakaoTalk chat list: AXTable > AXRow > AXCell > AXStaticText(id="_NS:18")
+    /// KakaoTalk chat list: AXTable > AXRow > AXCell > AXStaticText(name) ...
+    /// 채팅 이름 AXStaticText의 identifier는 KakaoTalk 버전마다 다르다(_NS:18, _NS:40 등).
+    /// 따라서 고정 id로 찾지 않고, 셀의 "첫 번째 AXStaticText"(=이름 라벨)만 검사한다.
+    /// 그 뒤에 오는 카운트/시간/미리보기 AXStaticText 와의 오매칭을 막기 위해 첫 항목에서 멈춘다.
     public static func findChatRow(_ table: AXUIElement, chatName: String, exact: Bool = false) -> AXUIElement? {
         for row in children(table) {
             guard role(row) == "AXRow" else { continue }
             for cell in children(row) {
                 guard role(cell) == "AXCell" else { continue }
                 for child in children(cell) {
-                    if role(child) == "AXStaticText" && identifier(child) == "_NS:18" {
+                    if role(child) == "AXStaticText" {
                         let name = value(child) ?? ""
                         let matches = exact ? name == chatName : name.localizedCaseInsensitiveContains(chatName)
                         if matches {
                             return row
                         }
+                        break  // 첫 AXStaticText(이름)만 본다
                     }
                 }
             }


### PR DESCRIPTION
## Problem
`send` (and any named-chat lookup) fails with `Error: Chat '<name>' not found in the chat list` for every group chat on current KakaoTalk builds. Sending to self-chat via `--me` works, since it uses a separate lookup.

## Cause
`AXHelpers.findChatRow` reads the chat name from the `AXStaticText` whose identifier is `"_NS:18"`:

```swift
if role(child) == "AXStaticText" && identifier(child) == "_NS:18" {
```

On the KakaoTalk build I tested, the name label has moved to `"_NS:40"`, and `"_NS:18"` is now the badge **image** (`AXImage`, e.g. `desc="badge warehouse room"`). So the name match never succeeds. Verified with `kakaocli inspect`:

```
[AXImage]      desc="badge warehouse room" id="_NS:18"   ← code looks here (image)
[AXStaticText] value="<chat name>"          id="_NS:40"   ← actual name label
```

## Fix
Match the **first `AXStaticText` in each cell** (the name label) regardless of its `_NS:*` identifier, and `break` after it so the trailing count/time/preview labels can't cause a mismatch. This is resilient to KakaoTalk renumbering the identifiers in future updates.

## Testing
Built with `swift build -c release` and confirmed a real group send now succeeds (`Message sent to '<group>'`, message present in `NTChatMessage`). Self-chat send still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)